### PR TITLE
EVA-611: variant browser css changes

### DIFF
--- a/src/css/eva.css
+++ b/src/css/eva.css
@@ -255,8 +255,8 @@ a, a:active, a:focus {
     padding: 5px 0 0 0px;
 }
 
-.x-grid-item-selected {
-    background-color: #ffffff;
+.x-grid-item-selected .x-grid-row {
+    background-color: #E6E6E6;
 }
 
 .eva-header-1 {
@@ -484,9 +484,8 @@ a, a:active, a:focus {
 
 .vcf-header {
     height: auto;
-    width: 960px;
     max-height: 270px !important;
-    overflow: hidden;
+    overflow: scroll;
     background-color: #F2F2EC;
     word-break: normal !important;
     word-wrap: normal !important;


### PR DESCRIPTION

It is not possible to see what variant is selected in the top table when browsing the in-depth data.

Fix is to highlight row selected in the top table.
