### PR TITLE
EVA-721: Use single variant info in Variant Browser bottom tab

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -42,7 +42,7 @@ module.exports = function (grunt) {
                     'src/js/variant-widget/eva-variant-widget-panel.js',
                     'src/js/variant-widget/eva-variant-widget.js',
                     'src/js/variant-widget/eva-variant-browser-grid.js',
-                    'src/js/variant-widget/eva-variant-stats-panel.js',
+                    'src/js/variant-widget/eva-variant-files-panel.js',
                     'src/js/variant-widget/eva-variant-genotype-grid-panel.js',
                     'src/js/variant-widget/eva-variant-population-stats-panel.js',
                     'src/js/variant-widget/filters/eva-form-panel.js',

--- a/src/index.html
+++ b/src/index.html
@@ -645,7 +645,7 @@
 <script type="text/javascript" src="js/beacon-form/eva-beacon-panel.js"></script>
 <script type="text/javascript" src="js/variant-widget/eva-variant-widget.js"></script>
 <script type="text/javascript" src="js/variant-widget/eva-variant-browser-grid.js"></script>
-<script type="text/javascript" src="js/variant-widget/eva-variant-stats-panel.js"></script>
+<script type="text/javascript" src="js/variant-widget/eva-variant-files-panel.js"></script>
 <script type="text/javascript" src="js/variant-widget/eva-variant-genotype-grid-panel.js"></script>
 <script type="text/javascript" src="js/variant-widget/eva-variant-population-stats-panel.js"></script>
 <script type="text/javascript" src="js/views/eva-study-view.js"></script>

--- a/src/js/variant-widget/eva-variant-files-panel.js
+++ b/src/js/variant-widget/eva-variant-files-panel.js
@@ -18,11 +18,11 @@
  * You should have received a copy of the GNU General Public License
  * along with JSorolla. If not, see <http://www.gnu.org/licenses/>.
  */
-function EvaVariantStatsPanel(args) {
+function EvaVariantFilesPanel(args) {
     _.extend(this, Backbone.Events);
-    this.id = Utils.genId("VariantStatsPanel");
+    this.id = Utils.genId("VariantFilesPanel");
     this.target;
-    this.title = "Stats";
+    this.title = "Files";
     this.height = 500;
     this.autoRender = true;
     this.statsTpl = new Ext.XTemplate(
@@ -61,7 +61,7 @@ function EvaVariantStatsPanel(args) {
     }
 }
 
-EvaVariantStatsPanel.prototype = {
+EvaVariantFilesPanel.prototype = {
     render: function () {
         var _this = this;
 
@@ -121,7 +121,7 @@ EvaVariantStatsPanel.prototype = {
                     xtype: 'box',
                     id: 'fileStats',
                     cls: 'ocb-header-4',
-                    html: '<h4>Files and Statistics <span class="icon icon-generic title-header-icon" data-icon="i"  data-qtip="Per-study reports of the selected variant. The compulsory fields and the metadata section from the source VCF files are displayed." style="margin-bottom:2px;"></span></h4>',
+                    html: '<h4>Files <span class="icon icon-generic title-header-icon" data-icon="i"  data-qtip="Per-study reports of the selected variant. The compulsory fields and the metadata section from the source VCF files are displayed." style="margin-bottom:2px;"></span></h4>',
                     margin: '5 0 10 15'
                 },
                 this.studiesContainer

--- a/src/js/variant-widget/eva-variant-widget-panel.js
+++ b/src/js/variant-widget/eva-variant-widget-panel.js
@@ -503,6 +503,7 @@ EvaVariantWidgetPanel.prototype = {
                     _this.formPanelVariantFilter.filters[5].grid.getSelectionModel().select(selectStudies)
                 }
 
+                _this.selectStudies = '';
                 _this.trigger('studies:change', {studies: studies, sender: _this});
             }
         });

--- a/src/js/variant-widget/eva-variant-widget.js
+++ b/src/js/variant-widget/eva-variant-widget.js
@@ -651,11 +651,11 @@ EvaVariantWidget.prototype = {
             } else {
                 if (target.id === _this.selectedToolDiv.id) {
                     var variant = e.variant;
-                    var region = variant.chromosome + ':' + variant.start + '-' + variant.end;
+                    var region = variant.chromosome + ':' + variant.start + ':' + variant.reference + ':' + variant.alternate;
                     var proxy = _.clone(this.variantBrowserGrid.store.proxy);
                     EvaManager.get({
-                        category: 'segments',
-                        resource: 'variants',
+                        category: 'variants',
+                        resource: 'info',
                         query: region,
                         params: {species: proxy.extraParams.species, studies: proxy.extraParams.studies},
                         async: false,
@@ -902,7 +902,6 @@ EvaVariantWidget.prototype = {
                 if (target.id === _this.selectedToolDiv.id) {
                     _.extend(e.variant, {annot: e.variant.annotation});
                     var proxy = _.clone(this.variantBrowserGrid.store.proxy);
-                    console.log(e.variant)
                     annotationPanel.load(e.variant, proxy.extraParams);
                     //sending tracking data to Google Analytics
                     ga('send', 'event', { eventCategory: 'Variant Browser', eventAction: 'Tab Views', eventLabel:'Annotation'});
@@ -948,11 +947,11 @@ EvaVariantWidget.prototype = {
             } else {
                 if (target.id === _this.selectedToolDiv.id) {
                     var variant = e.variant;
-                    var region = variant.chromosome + ':' + variant.start + '-' + variant.end;
+                    var region = variant.chromosome + ':' + variant.start + ':' + variant.reference + ':' + variant.alternate;
                     var proxy = _.clone(this.variantBrowserGrid.store.proxy);
                     EvaManager.get({
-                        category: 'segments',
-                        resource: 'variants',
+                        category: 'variants',
+                        resource: 'info',
                         query: region,
                         params: {species: proxy.extraParams.species, studies: proxy.extraParams.studies},
                         async: false,
@@ -1016,13 +1015,13 @@ EvaVariantWidget.prototype = {
             } else {
                 if (target.id === _this.selectedToolDiv.id) {
                     var variant = e.variant;
-                    var query = e.variant.chromosome + ':' + e.variant.start + '-' + e.variant.end;
+                    var region = variant.chromosome + ':' + variant.start + ':' + variant.reference + ':' + variant.alternate;
                     var params = _.omit(_this.variantBrowserGrid.store.proxy.extraParams, 'region');
 
                     EvaManager.get({
-                        category: 'segments',
-                        resource: 'variants',
-                        query: query,
+                        category: 'variants',
+                        resource: 'info',
+                        query: region,
                         params: params,
                         success: function (response) {
                             try {

--- a/src/js/variant-widget/eva-variant-widget.js
+++ b/src/js/variant-widget/eva-variant-widget.js
@@ -147,12 +147,12 @@ EvaVariantWidget.prototype = {
         }
 
         if (this.defaultToolConfig.stats) {
-            this.variantStatsPanelDiv = document.createElement('div');
-            this.variantStatsPanelDiv.setAttribute('class', 'ocb-variant-stats-panel');
-            this.variantStatsPanel = this._createVariantStatsPanel(this.variantStatsPanelDiv);
+            this.variantFilesPanelDiv = document.createElement('div');
+            this.variantFilesPanelDiv.setAttribute('class', 'ocb-variant-stats-panel');
+            this.variantFilesPanel = this._createVariantFilesPanel(this.variantFilesPanelDiv);
             tabPanelItems.push({
                 title: 'Files',
-                contentEl: this.variantStatsPanelDiv
+                contentEl: this.variantFilesPanelDiv
             });
         }
 
@@ -228,7 +228,7 @@ EvaVariantWidget.prototype = {
         }
 
         if (this.defaultToolConfig.stats) {
-            this.variantStatsPanel.draw();
+            this.variantFilesPanel.draw();
         }
 
         if (this.defaultToolConfig.populationStats) {
@@ -618,9 +618,9 @@ EvaVariantWidget.prototype = {
         }, this);
         return variantBrowserGrid;
     },
-    _createVariantStatsPanel: function (target) {
+    _createVariantFilesPanel: function (target) {
         var _this = this;
-        var variantStatsPanel = new EvaVariantStatsPanel({
+        var variantFilesPanel = new EvaVariantFilesPanel({
             target: target,
             height: 820,
             statsTpl: new Ext.XTemplate(
@@ -642,17 +642,17 @@ EvaVariantWidget.prototype = {
         });
 
         this.variantBrowserGrid.on("variant:clear", function (e) {
-            variantStatsPanel.clear(true);
+            variantFilesPanel.clear(true);
         });
 
 
 
         this.on("variant:change", function (e) {
             if (_.isUndefined(e.variant)) {
-                variantStatsPanel.clear(true);
+                variantFilesPanel.clear(true);
             } else {
                 if (target.id === _this.selectedToolDiv.id) {
-                    _this.loadBottomPanel(variantStatsPanel, e.variant);
+                    _this.loadBottomPanel(variantFilesPanel, e.variant);
                     //sending tracking data to Google Analytics
                     ga('send', 'event', { eventCategory: 'Variant Browser', eventAction: 'Tab Views', eventLabel:'Files'});
                 }
@@ -661,7 +661,7 @@ EvaVariantWidget.prototype = {
         });
 
 
-        return variantStatsPanel;
+        return variantFilesPanel;
     },
     _createAnnotationPanel: function (target) {
         var _this = this;
@@ -1252,7 +1252,7 @@ EvaVariantWidget.prototype = {
     loadBottomPanel : function (panel, variant){
         var _this = this;
         var region = variant.chromosome + ':' + variant.start + ':' + variant.reference + ':' + variant.alternate;
-        var proxy = _.clone(this.variantBrowserGrid.store.proxy);
+        var proxy = _.clone(_this.variantBrowserGrid.store.proxy);
         EvaManager.get({
             category: 'variants',
             resource: 'info',

--- a/src/js/variant-widget/eva-variant-widget.js
+++ b/src/js/variant-widget/eva-variant-widget.js
@@ -645,33 +645,14 @@ EvaVariantWidget.prototype = {
             variantStatsPanel.clear(true);
         });
 
+
+
         this.on("variant:change", function (e) {
             if (_.isUndefined(e.variant)) {
                 variantStatsPanel.clear(true);
             } else {
                 if (target.id === _this.selectedToolDiv.id) {
-                    var variant = e.variant;
-                    var region = variant.chromosome + ':' + variant.start + ':' + variant.reference + ':' + variant.alternate;
-                    var proxy = _.clone(this.variantBrowserGrid.store.proxy);
-                    EvaManager.get({
-                        category: 'variants',
-                        resource: 'info',
-                        query: region,
-                        params: {species: proxy.extraParams.species, studies: proxy.extraParams.studies},
-                        async: false,
-                        success: function (response) {
-                            try {
-//                                _.extend(variant, response.response[0].result[0]);
-                                var result = _.findWhere(response.response[0].result, {start: variant.start,end:variant.end});
-                                _.extend(variant,result);
-                            } catch (e) {
-                                console.log(e);
-                            }
-                        }
-                    });
-                    if (variant.sourceEntries) {
-                        variantStatsPanel.load(variant.sourceEntries, {species: proxy.extraParams.species},_this.studies);
-                    }
+                    _this.loadBottomPanel(variantStatsPanel, e.variant);
                     //sending tracking data to Google Analytics
                     ga('send', 'event', { eventCategory: 'Variant Browser', eventAction: 'Tab Views', eventLabel:'Files'});
                 }
@@ -946,28 +927,7 @@ EvaVariantWidget.prototype = {
                 variantPopulationStatsPanel.clear(true);
             } else {
                 if (target.id === _this.selectedToolDiv.id) {
-                    var variant = e.variant;
-                    var region = variant.chromosome + ':' + variant.start + ':' + variant.reference + ':' + variant.alternate;
-                    var proxy = _.clone(this.variantBrowserGrid.store.proxy);
-                    EvaManager.get({
-                        category: 'variants',
-                        resource: 'info',
-                        query: region,
-                        params: {species: proxy.extraParams.species, studies: proxy.extraParams.studies},
-                        async: false,
-                        success: function (response) {
-                            try {
-//                                _.extend(variant, response.response[0].result[0]);
-                                var result = _.findWhere(response.response[0].result, {start: variant.start,end:variant.end});
-                                _.extend(variant,result);
-                            } catch (e) {
-                                console.log(e);
-                            }
-                        }
-                    });
-                    if (variant.sourceEntries) {
-                        variantPopulationStatsPanel.load(variant.sourceEntries, proxy.extraParams,_this.studies);
-                    }
+                    _this.loadBottomPanel(variantPopulationStatsPanel, e.variant);
                     //sending tracking data to Google Analytics
                     ga('send', 'event', { eventCategory: 'Variant Browser', eventAction: 'Tab Views', eventLabel:'Population Statistics'});
                 }
@@ -1014,34 +974,9 @@ EvaVariantWidget.prototype = {
                 variantGenotypeGridPanel.clear(true);
             } else {
                 if (target.id === _this.selectedToolDiv.id) {
-                    var variant = e.variant;
-                    var region = variant.chromosome + ':' + variant.start + ':' + variant.reference + ':' + variant.alternate;
-                    var params = _.omit(_this.variantBrowserGrid.store.proxy.extraParams, 'region');
-
-                    EvaManager.get({
-                        category: 'variants',
-                        resource: 'info',
-                        query: region,
-                        params: params,
-                        success: function (response) {
-                            try {
-//                                var variantSourceEntries = response.response[0].result[0].sourceEntries;
-                                var result = _.findWhere(response.response[0].result, {start: variant.start,end:variant.end});
-                                var variantSourceEntries = result.sourceEntries;
-
-                            } catch (e) {
-
-                                console.log(e);
-                            }
-
-                            if (variantSourceEntries) {
-                                variantGenotypeGridPanel.load(variantSourceEntries, params, _this.studies);
-                            }
-                        }
-                    });
+                    _this.loadBottomPanel(variantGenotypeGridPanel, e.variant);
                     //sending tracking data to Google Analytics
                     ga('send', 'event', { eventCategory: 'Variant Browser', eventAction: 'Tab Views', eventLabel:'Genotypes'});
-
                 }
             }
 
@@ -1260,7 +1195,6 @@ EvaVariantWidget.prototype = {
             alert('Please allow pop up in settings if its not exporting');
             window.open().document.write('<table>' + csvContent + '</table>');
             return true;
-
         }
 
 
@@ -1314,5 +1248,28 @@ EvaVariantWidget.prototype = {
         var values = {variantId: id, dbsnpURL: dbsnpURL};
 
         return values;
+    },
+    loadBottomPanel : function (panel, variant){
+        var _this = this;
+        var region = variant.chromosome + ':' + variant.start + ':' + variant.reference + ':' + variant.alternate;
+        var proxy = _.clone(this.variantBrowserGrid.store.proxy);
+        EvaManager.get({
+            category: 'variants',
+            resource: 'info',
+            query: region,
+            params: {species: proxy.extraParams.species, studies: proxy.extraParams.studies},
+            async: false,
+            success: function (response) {
+                try {
+                    var result = _.findWhere(response.response[0].result, {start: variant.start,end:variant.end});
+                    _.extend(variant,result);
+                } catch (e) {
+                    console.log(e);
+                }
+            }
+        });
+        if (variant.sourceEntries) {
+            panel.load(variant.sourceEntries, {species: proxy.extraParams.species},_this.studies);
+        }
     }
 };

--- a/src/js/views/eva-variant-view.js
+++ b/src/js/views/eva-variant-view.js
@@ -87,9 +87,9 @@ EvaVariantView.prototype = {
         //sending tracking data to Google Analytics
         ga('send', 'event', { eventCategory: 'Views', eventAction: 'Variant', eventLabel:'species='+this.species+'variant='+this.position});
     },
-    createVariantStatsPanel: function (data) {
+    createVariantFilesPanel: function (data) {
         var _this = this;
-        var variantStatsPanel = new EvaVariantStatsPanel({
+        var variantFilesPanel = new EvaVariantFilesPanel({
             target: data,
             height: '',
             handlers: {
@@ -126,11 +126,11 @@ EvaVariantView.prototype = {
 
 
         if (variant[0].sourceEntries) {
-            variantStatsPanel.load(variant[0].sourceEntries, {species: this.species},  _this.studiesList);
+            variantFilesPanel.load(variant[0].sourceEntries, {species: this.species},  _this.studiesList);
         }
-        variantStatsPanel.draw();
+        variantFilesPanel.draw();
 
-        return variantStatsPanel;
+        return variantFilesPanel;
     },
 
     draw: function (data, content) {
@@ -160,7 +160,7 @@ EvaVariantView.prototype = {
         var studyElDiv = document.createElement("div");
         studyElDiv.setAttribute('class', 'eva variant-widget-panel ocb-variant-stats-panel');
         studyEl.appendChild(studyElDiv);
-        _this.createVariantStatsPanel(studyElDiv);
+        _this.createVariantFilesPanel(studyElDiv);
 
         var popStatsEl = document.querySelector("#population-stats-grid-view");
         var popStatsElDiv = document.createElement("div");

--- a/tests/mocha/config.js
+++ b/tests/mocha/config.js
@@ -1,5 +1,5 @@
 // var baseURL = 'http://wwwdev.ebi.ac.uk/eva';
-var baseURL = 'http://localhost/eva-web/build/3.1.0/index.html';
+var baseURL = 'http://localhost/eva-web/build/3.2.0/index.html';
 // var baseURL = 'http://localhost/eva-web/src/index.html';
 var browser = process.env.BROWSER;
 


### PR DESCRIPTION
When clicking on the Variant View link for a single variant, the REST endpoint variants/{variantId}/info is called.
On the other hand, when selecting a variant in the Variant Browser to view the details in the bottom tab, the segments/{segmentId}/variants endpoint is called, which can lead to problems if more than one allele has been reported in that position.
The variants/{variantId}/info must be used in that case.