### PR TITLE
EVA-682:First row of Variant Browser top table alignment broken after clicking on bottom tabs

### DIFF
--- a/src/js/variant-widget/eva-variant-widget.js
+++ b/src/js/variant-widget/eva-variant-widget.js
@@ -49,7 +49,7 @@ function EvaVariantWidget(args) {
         },
         genomeViewer: false,
         genotype: true,
-        stats: true,
+        files: true,
         populationStats: true,
         annotation: true,
         clinvarAssertion:true
@@ -146,7 +146,7 @@ EvaVariantWidget.prototype = {
             });
         }
 
-        if (this.defaultToolConfig.stats) {
+        if (this.defaultToolConfig.files) {
             this.variantFilesPanelDiv = document.createElement('div');
             this.variantFilesPanelDiv.setAttribute('class', 'ocb-variant-stats-panel');
             this.variantFilesPanel = this._createVariantFilesPanel(this.variantFilesPanelDiv);
@@ -227,7 +227,7 @@ EvaVariantWidget.prototype = {
             this.annotationPanel.draw();
         }
 
-        if (this.defaultToolConfig.stats) {
+        if (this.defaultToolConfig.files) {
             this.variantFilesPanel.draw();
         }
 
@@ -1261,15 +1261,14 @@ EvaVariantWidget.prototype = {
             async: false,
             success: function (response) {
                 try {
-                    var result = _.findWhere(response.response[0].result, {start: variant.start,end:variant.end});
-                    _.extend(variant,result);
+                    var result = response.response[0].result[0];
+                    if (result.sourceEntries) {
+                        panel.load(result.sourceEntries, {species: proxy.extraParams.species},_this.studies);
+                    }
                 } catch (e) {
                     console.log(e);
                 }
             }
         });
-        if (variant.sourceEntries) {
-            panel.load(variant.sourceEntries, {species: proxy.extraParams.species},_this.studies);
-        }
     }
 };


### PR DESCRIPTION
Steps to reproduce:
Execute a Variant Browser search
Select a variant
Click on the "Files" or "Population Statistics" bottom tabs
The alignment of the first row in the top table is not correct