### PR TITLE
EVA-664:annotation table biotype column renamed

### DIFF
--- a/src/js/clinvar/eva-clinvar-annotation-panel.js
+++ b/src/js/clinvar/eva-clinvar-annotation-panel.js
@@ -51,6 +51,13 @@ function ClinvarAnnotationPanel(args) {
                 tpl: '<tpl if="ensemblTranscriptId"><a href="http://www.ensembl.org/Homo_sapiens/transview?transcript={ensemblTranscriptId}" target="_blank">{ensemblTranscriptId}</a><tpl else>-</tpl>',
             },
             {
+                text: "Ensembl <br />Transcript Biotype",
+                dataIndex: "biotype",
+                xtype: "templatecolumn",
+                tpl: '<tpl if="biotype">{biotype}<tpl else>-</tpl>',
+                flex: 1.3
+            },
+            {
                 text: "SO Term(s)",
                 dataIndex: "soTerms",
                 flex: 1.7,
@@ -86,13 +93,6 @@ function ClinvarAnnotationPanel(args) {
                     }
 
                 }
-            },
-            {
-                text: "Biotype",
-                dataIndex: "biotype",
-                xtype: "templatecolumn",
-                tpl: '<tpl if="biotype">{biotype}<tpl else>-</tpl>',
-                flex: 1.3
             },
             {
                 text: "Codon",

--- a/src/js/variant-widget/eva-variant-widget.js
+++ b/src/js/variant-widget/eva-variant-widget.js
@@ -692,6 +692,13 @@ EvaVariantWidget.prototype = {
                     tpl: '<tpl if="ensemblTranscriptId">{ensemblTranscriptId}<tpl else>-</tpl>'
                 },
                 {
+                    text: "Ensembl <br />Transcript Biotype",
+                    dataIndex: "biotype",
+                    xtype: "templatecolumn",
+                    tpl: '<tpl if="biotype">{biotype}<tpl else>-</tpl>',
+                    flex: 1.1
+                },
+                {
                     text: "SO Term(s)",
                     dataIndex: "soTerms",
                     flex: 1.7,
@@ -728,13 +735,6 @@ EvaVariantWidget.prototype = {
                         }
 
                     }
-                },
-                {
-                    text: "Biotype",
-                    dataIndex: "biotype",
-                    xtype: "templatecolumn",
-                    tpl: '<tpl if="biotype">{biotype}<tpl else>-</tpl>',
-                    flex: 1.1
                 },
                 {
                     text: "Codon",


### PR DESCRIPTION
This column should be renamed to "Ensembl Transcript Biotype", as it is currently unclear to what this refers to.
Also the order of the columns should be changed so that the Biotype column comes after the "Ensembl Transcript ID" column.