### PR TITLE
EVA-726: Delete Clinical Submissions Templat

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -299,9 +299,6 @@
                         <p>Unless fully described in the header of the VCF file(s), EVA submissions are accompanied by an Excel spreadsheet and/or tab-delimited text files which describe the meta-data. We encourage our users to submit as much metadata as possible.</p>
                         <p>Please download our submission template via this <a href="files/EVA_Submission_template.V1.0.3_final.xlsx" target="_blank">link</a>.</p>
                         <p>A completed template for a fictional submission can be downloaded <a href="files/EVA_Submission_template.V1.0.3_final_mockup.xlsx" target="_blank">here</a>.</p>
-                        <h3>EVA Clincal Submissions</h3>
-                        <p>EVA Clinical submissions are described via an Excel spreadsheet and/or tab-delimited text files. Our submissions templates are fully compliant with the data required for ClinVar allowing us to broker the submission of all EVA Clincal data to our collaborating NCBI resource.</p>
-                        <p>Please download our EVA Clinical submission template via this <a href="files/SubmissionTemplate.xlsx" target="_blank">link</a>.</p>
                     </div>
                 </div>
 


### PR DESCRIPTION
delete the "EVA Clinical Submissions" and the text below from this page: http://www.ebi.ac.uk/eva/?Templates