### PR TITLE
EVA-665: Remove Bubbles in Variant Browser and instead print text

### DIFF
--- a/src/js/clinvar/eva-clinvar-annotation-panel.js
+++ b/src/js/clinvar/eva-clinvar-annotation-panel.js
@@ -164,14 +164,14 @@ ClinvarAnnotationPanel.prototype = {
                 var annText = _.findWhere(annotation_text, {species: params.species})
                 if (!_.isEmpty(annText.text)) {
                     var tooltip = annText.text;
-                    Ext.getCmp(_this.id + '-annotationStats').update('<h4>Annotations <span class="icon icon-generic title-header-icon" data-icon="i" data-qtip="' + tooltip + '" style="margin-bottom:2px;"></span></h4>')
+                    Ext.getCmp(_this.id + '-annotationStats').update('<h4>Annotations</h4><h6><small>'+tooltip+'</small></h6>')
                 } else {
                     Ext.getCmp(_this.id + '-annotationStats').update('<h4>Annotations</h4>')
                 }
             }
 
         } else {
-            Ext.getCmp(_this.id + '-annotationStats').update('<h4>Annotations <span class="icon icon-generic title-header-icon" data-icon="i" data-qtip="Variant Effect Predictor (VEP) v78 annotation against the GENCODE Basic Ensembl v78 geneset." style="margin-bottom:2px;"></span></h4>')
+            Ext.getCmp(_this.id + '-annotationStats').update('<h4>Annotations</h4><h6><small>Variant Effect Predictor (VEP) v78 annotation against the GENCODE Basic Ensembl v78 geneset.</small></h6>')
         }
         var panel = this._createAnnotPanel(annotData);
         this.annotContainer.removeAll();

--- a/src/js/variant-widget/eva-variant-files-panel.js
+++ b/src/js/variant-widget/eva-variant-files-panel.js
@@ -120,8 +120,8 @@ EvaVariantFilesPanel.prototype = {
                 {
                     xtype: 'box',
                     id: 'fileStats',
-                    cls: 'ocb-header-4',
-                    html: '<h4>Files</h4><h6><small>Files Per-study reports of the selected variant. The compulsory fields and the metadata section from the source VCF files are displayed.</small></h6>',
+                    cls: 'ocb-header-4',    
+                    html: '<h4>Files</h4><h6><small>Per-study reports of the selected variant. The compulsory fields and the metadata section from the source VCF file(s) are displayed.</small></h6>',
                 margin: '5 0 10 15'
                 },
                 this.studiesContainer

--- a/src/js/variant-widget/eva-variant-files-panel.js
+++ b/src/js/variant-widget/eva-variant-files-panel.js
@@ -121,8 +121,8 @@ EvaVariantFilesPanel.prototype = {
                     xtype: 'box',
                     id: 'fileStats',
                     cls: 'ocb-header-4',
-                    html: '<h4>Files <span class="icon icon-generic title-header-icon" data-icon="i"  data-qtip="Per-study reports of the selected variant. The compulsory fields and the metadata section from the source VCF files are displayed." style="margin-bottom:2px;"></span></h4>',
-                    margin: '5 0 10 15'
+                    html: '<h4>Files</h4><h6><small>Files Per-study reports of the selected variant. The compulsory fields and the metadata section from the source VCF files are displayed.</small></h6>',
+                margin: '5 0 10 15'
                 },
                 this.studiesContainer
             ],

--- a/src/js/variant-widget/eva-variant-genotype-grid-panel.js
+++ b/src/js/variant-widget/eva-variant-genotype-grid-panel.js
@@ -94,7 +94,7 @@ EvaVariantGenotypeGridPanel.prototype = {
         for (var key in data) {
             var study = data[key];
             if (Object.keys(study.samplesData).length > 0) {
-                Ext.getCmp('genotypeTitle').update('<h4>Genotypes <span class="icon icon-generic title-header-icon" data-icon="i" data-qtip="'+this.tooltipText+'" style="margin-bottom:2px;"></span></h4>')
+                Ext.getCmp('genotypeTitle').update('<h4>Genotypes</h4><h6><small>'+this.tooltipText+'</small></h6>')
                 var genotypePanel = this._createGenotypePanel(study, params, studies);
                 genotypeChartData.push(genotypePanel.chartData)
                 panels.push(genotypePanel);
@@ -102,7 +102,7 @@ EvaVariantGenotypeGridPanel.prototype = {
         }
 
         if (_.isEmpty(panels)) {
-            Ext.getCmp('genotypeTitle').update('<h4>Genotypes <span class="icon icon-generic title-header-icon" data-icon="i" data-qtip="'+this.tooltipText+'" style="margin-bottom:2px;"></span></h4><p class="genotype-grid-no-data">No Genotypes data available</p>')
+            Ext.getCmp('genotypeTitle').update('<h4>Genotypes</h4><p class="genotype-grid-no-data">No Genotypes data available</p>')
         }
         this.clear();
         panels = _.sortBy(panels, 'projectName');
@@ -133,7 +133,7 @@ EvaVariantGenotypeGridPanel.prototype = {
                     xtype: 'box',
                     id: 'genotypeTitle',
                     cls: 'ocb-header-4',
-                    html: '<h4>Genotypes <span class="icon icon-generic title-header-icon" data-icon="i" data-qtip="'+this.tooltipText+'" style="margin-bottom:2px;"></span></h4>',
+                    html: '<h4>Genotypes</h4><h6><small>'+this.tooltipText+'</small></h6>',
                     margin: '5 0 10 10'
                 },
                 this.studiesContainer

--- a/src/js/variant-widget/eva-variant-population-stats-panel.js
+++ b/src/js/variant-widget/eva-variant-population-stats-panel.js
@@ -114,7 +114,7 @@ EvaVariantPopulationStatsPanel.prototype = {
                     xtype: 'box',
                     id: 'populationStats',
                     cls: 'ocb-header-4',
-                    html: '<h4>Population Statistics <span class="icon icon-generic title-header-icon" data-icon="i"  data-qtip="'+this.tooltipText+'" style="margin-bottom:2px;"></span></h4><p class="genotype-grid-no-data">&nbsp;No Population data available</p>',
+                    html: '<h4>Population Statistics</h4><p class="genotype-grid-no-data">&nbsp;No Population data available</p>',
                     margin: '5 0 10 15'
                 },
                 this.studiesContainer
@@ -212,10 +212,10 @@ EvaVariantPopulationStatsPanel.prototype = {
         };
 
         if (_.isEmpty(populationData)) {
-            Ext.getCmp('populationStats').update('<h4>Population Statistics <span class="icon icon-generic title-header-icon" data-icon="i"  data-qtip="'+this.tooltipText+'" style="margin-bottom:2px;"></span></h4><p class="genotype-grid-no-data">&nbsp;No Population data available</p>')
+            Ext.getCmp('populationStats').update('<h4>Population Statistics</h4><p class="genotype-grid-no-data">&nbsp;No Population data available</p>')
             return;
         } else {
-            Ext.getCmp('populationStats').update('<h4>Population Statistics <span class="icon icon-generic title-header-icon" data-icon="i"  data-qtip="'+this.tooltipText+'" style="margin-bottom:2px;"></span></h4>')
+            Ext.getCmp('populationStats').update('<h4>Population Statistics</h4><h6><small>'+this.tooltipText+'</small></h6>')
         }
         var store = Ext.create("Ext.data.Store", {
             //storeId: "GenotypeStore",


### PR DESCRIPTION
I don't think it is obvious to people that the 'i" icons are able to be hovered over for more information. This comes from a number of workshops including today's at University of Cambridge. I think it is better to remove the bubbles and print the text. For example, the VEP and e! versions that are shown when hovering over the "i" in the Annotation tab.