### PR TITLE
EVA-762: Link to Swagger documentation broken

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -322,7 +322,7 @@
                             <br/> * <span class="api-span">filters</span>: each specific endpoint allows different filters.
                         </p>
                         <div>
-                            <p>REST web services have been implemented using GET protocol since only queries are allowed so far. Several IDs can be concatenated using comma as separator.<br/>For more detailed information about the API and filters you can visit the <a href="https://github.com/ebivariation/eva/wiki" target="_blank">project wiki</a> and <a href="http://www.ebi.ac.uk/eva/webservices/api/" target="_blank">Swagger documentation</a>.</p>
+                            <p>REST web services have been implemented using GET protocol since only queries are allowed so far. Several IDs can be concatenated using comma as separator.<br/>For more detailed information about the API and filters you can visit the <a href="https://github.com/ebivariation/eva/wiki" target="_blank">project wiki</a> and <a href="https://www.ebi.ac.uk/eva/webservices/rest/swagger-ui.html" target="_blank">Swagger documentation</a>.</p>
                         </div>
                         <div>
                             <h3>Some example of queries include:</h3>


### PR DESCRIPTION
On the API page, the link to the Swagger documentation should point to https://hostname/eva/webservices/rest/swagger-ui.html instead of http://hostname/eva/webservices/api/.