### PR TITLE
EVA-762: Remove ERA FTP links from Variant Browser tabs

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,7 +15,7 @@ module.exports = function (grunt) {
         // Metadata.
         meta: {
             version: {
-                eva: '3.3.0'
+                eva: '3.3.1'
             }
         },
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "eva-web",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "homepage": "https://github.com/EBIvariation/eva-web",
   "authors": [
     "kandaj <kandaj@ebi.ac.uk>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commons",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "javascript commons",
   "repository": {
     "type": "git",

--- a/src/js/variant-widget/eva-variant-files-panel.js
+++ b/src/js/variant-widget/eva-variant-files-panel.js
@@ -154,9 +154,9 @@ EvaVariantFilesPanel.prototype = {
             }
         }
 
-        study_title = project_name + ' (' + data.studyId +' - <a href="ftp://ftp.ebi.ac.uk/pub/databases/eva/' + data.studyId + '/'+fileId+'" class="ftp_link" target="_blank">' + fileId + '</a>)';
+        study_title = project_name + ' (' + data.studyId +')';
         if(link){
-            study_title = '<a href="?eva-study=' + data.studyId + '" class="study_link" target="_blank">' + project_name + '</a> (<a href="?eva-study=' + data.studyId + '" class="project_link" target="_blank">' + data.studyId +'</a> - <a href="ftp://ftp.ebi.ac.uk/pub/databases/eva/' + data.studyId + '/'+fileId+'" class="ftp_link" target="_blank">' + fileId + '</a>)';
+            study_title = '<a href="?eva-study=' + data.studyId + '" class="study_link" target="_blank">' + project_name + '</a> (<a href="?eva-study=' + data.studyId + '" class="project_link" target="_blank">' + data.studyId +'</a>)';
         }
 
         var infoTags = '';

--- a/src/js/variant-widget/eva-variant-genotype-grid-panel.js
+++ b/src/js/variant-widget/eva-variant-genotype-grid-panel.js
@@ -156,9 +156,9 @@ EvaVariantGenotypeGridPanel.prototype = {
             }
         }
 
-        study_title = project_name + ' (' + data.studyId +' - <a href="ftp://ftp.ebi.ac.uk/pub/databases/eva/' + data.studyId + '/'+fileId+'" class="ftp_link" target="_blank">' + fileId + '</a>)';
+        study_title = project_name + ' (' + data.studyId +')';
         if(link){
-            study_title = '<a href="?eva-study=' + data.studyId + '" class="study_link" target="_blank">' + project_name + '</a> (<a href="?eva-study=' + data.studyId + '" class="project_link" target="_blank">' + data.studyId +'</a> - <a href="ftp://ftp.ebi.ac.uk/pub/databases/eva/' + data.studyId + '/'+fileId+'" class="ftp_link" target="_blank">' + fileId + '</a>)';
+            study_title = '<a href="?eva-study=' + data.studyId + '" class="study_link" target="_blank">' + project_name + '</a> (<a href="?eva-study=' + data.studyId + '" class="project_link" target="_blank">' + data.studyId +'</a>)';
         }
 
         var samples = data.samplesData;

--- a/src/js/variant-widget/eva-variant-population-stats-panel.js
+++ b/src/js/variant-widget/eva-variant-population-stats-panel.js
@@ -145,9 +145,9 @@ EvaVariantPopulationStatsPanel.prototype = {
             }
         }
 
-        study_title = project_name + ' (' + data.studyId +' - <a href="ftp://ftp.ebi.ac.uk/pub/databases/eva/' + data.studyId + '/'+fileId+'" class="ftp_link" target="_blank">' + fileId + '</a>)';
+        study_title = project_name + ' (' + data.studyId +')';
         if(link){
-            study_title = '<a href="?eva-study=' + data.studyId + '" class="study_link" target="_blank">' + project_name + '</a> (<a href="?eva-study=' + data.studyId + '" class="project_link" target="_blank">' + data.studyId +'</a> - <a href="ftp://ftp.ebi.ac.uk/pub/databases/eva/' + data.studyId + '/'+fileId+'" class="ftp_link" target="_blank">' + fileId + '</a>)';
+            study_title = '<a href="?eva-study=' + data.studyId + '" class="study_link" target="_blank">' + project_name + '</a> (<a href="?eva-study=' + data.studyId + '" class="project_link" target="_blank">' + data.studyId +'</a>)';
         }
 
 

--- a/src/js/variant-widget/eva-variant-widget-panel.js
+++ b/src/js/variant-widget/eva-variant-widget-panel.js
@@ -238,7 +238,7 @@ EvaVariantWidgetPanel.prototype = {
         var studyFilter = new EvaStudyFilterFormPanel({
             border: false,
             collapsed: false,
-            height: 890,
+            height: 'auto',
             studiesStore: this.studiesStore,
             studyFilterTpl: '<tpl if="studyId"><div class="ocb-study-filter"><tpl if="link"><a href="?eva-study={studyId}" target="_blank">{studyName}</a> (<a href="?eva-study={studyId}" target="_blank">{studyId}</a>)<tpl else>{studyName} ({studyId}) </tpl></div><tpl else><div class="ocb-study-filter"><a href="?eva-study={studyId}" target="_blank">{studyName}</a></div></tpl>'
         });


### PR DESCRIPTION
The EVA variant browser displays hyperlinks to ERZ folder on the EVA FTP. We know that some of these hyperlinks are wrong.
In order to keep the Variant Browser and Study Browser functionalities separate we shall remove the FTP links from the Files, Genotypes and Population Statistics tabs. The remaining links to 'download data' shall be to the EVA Study Browser pages.
