### PR TITLE
EVA-909 'Submit' text in buttons replaced with 'Search'

### DIFF
--- a/src/js/beacon-form/eva-beacon-form.js
+++ b/src/js/beacon-form/eva-beacon-form.js
@@ -240,7 +240,7 @@ EvaBeaconForm.prototype = {
                     }
                 },
                 {
-                    text: 'Submit',
+                    text: 'Search',
                     formBind: true,
                     //only enabled once the form is valid
                     disabled: true,

--- a/src/js/clinvar/eva-clinical-widget-panel.js
+++ b/src/js/clinvar/eva-clinical-widget-panel.js
@@ -503,7 +503,7 @@ EvaClinicalWidgetPanel.prototype = {
             headerConfig: false,
             mode: 'accordion',
             target: target,
-            submitButtonText: 'Submit',
+            submitButtonText: 'Search',
             filters: [clinvarPositionFilter, clinvarConseqTypeFilter, phenotypeFilter, variationTypeFilter, clinicalSignfcFilter, reviewStatusFilter],
             height: 1408,
             border: false,

--- a/src/js/clinvar/eva-clinical-widget-panel.js
+++ b/src/js/clinvar/eva-clinical-widget-panel.js
@@ -504,6 +504,7 @@ EvaClinicalWidgetPanel.prototype = {
             mode: 'accordion',
             target: target,
             submitButtonText: 'Search',
+            submitButtonId: 'cb-submit-button',
             filters: [clinvarPositionFilter, clinvarConseqTypeFilter, phenotypeFilter, variationTypeFilter, clinicalSignfcFilter, reviewStatusFilter],
             height: 1408,
             border: false,

--- a/src/js/study-browser/eva-study-browser-widget-panel.js
+++ b/src/js/study-browser/eva-study-browser-widget-panel.js
@@ -204,7 +204,7 @@ EvaStudyBrowserWidgetPanel.prototype = {
             headerConfig: false,
             mode: 'accordion',
             target: target,
-            submitButtonText: 'Submit',
+            submitButtonText: 'Search',
             submitButtonId: 'study-submit-button',
             filters: [this.browserTypeFilter, this.searchFilter, this.speciesFilter, this.typeFilter],
             height: 1359,

--- a/src/js/variant-widget/eva-variant-widget-panel.js
+++ b/src/js/variant-widget/eva-variant-widget-panel.js
@@ -349,7 +349,7 @@ EvaVariantWidgetPanel.prototype = {
             headerConfig: false,
             mode: 'accordion',
             target: target,
-            submitButtonText: 'Submit',
+            submitButtonText: 'Search',
             submitButtonId: 'vb-submit-button',
             filters: [speciesFilter, positionFilter,annotationFilter,conseqTypeFilter,populationFrequencyFilter,proteinSubScoreFilter, studyFilter],
             height: 1359,

--- a/tests/acceptance/clinical_browser.js
+++ b/tests/acceptance/clinical_browser.js
@@ -117,7 +117,7 @@ function clinVarSearchByAccession(driver){
     driver.findElement(By.xpath("//li[text()='ClinVar Accession']")).click();
     driver.findElement(By.name("accessionId")).clear();
     driver.findElement(By.name("accessionId")).sendKeys("RCV000074666");
-    driver.findElement(By.xpath("//div[contains(@id,'ClinvarWidgetPanel')]//span[text()='Search']")).click();
+    config.submit(driver, "cb-submit-button");
     config.sleep(driver);
     driver.wait(until.elementLocated(By.xpath("//div[contains(@id,'clinvar-browser-grid-body')]//table[1]//td[8]/div/a[text()]")), config.wait()).then(function(text) {
         driver.findElement(By.xpath("//div[contains(@id,'clinvar-browser-grid-body')]//table[1]//td[8]/div/a[text()]")).getText().then(function(text){
@@ -142,7 +142,7 @@ function clinVarSearchByLocation(driver){
     driver.findElement(By.xpath("//li[text()='Chromosomal Location']")).click();
     driver.findElement(By.name("clinvarRegion")).clear();
     driver.findElement(By.name("clinvarRegion")).sendKeys("13:32889611-32973805");
-    driver.findElement(By.xpath("//div[contains(@id,'ClinvarWidgetPanel')]//span[text()='Search']")).click();
+    config.submit(driver, "cb-submit-button");
     config.sleep(driver);
     driver.wait(until.elementLocated(By.xpath("//div[contains(@id,'clinvar-browser-grid-body')]//table[2]//td[1]/div[text()]")), config.wait()).then(function(text) {
         driver.findElement(By.xpath("//div[contains(@id,'clinvar-browser-grid-body')]//table[2]//td[1]/div[text()]")).getText().then(function(text){
@@ -164,7 +164,7 @@ function clinVarSearchByGene(driver){
     driver.findElement(By.xpath("//li[text()='Ensembl Gene Symbol/Accession']")).click();
     driver.findElement(By.name("gene")).clear();
     driver.findElement(By.name("gene")).sendKeys("BRCA1");
-    driver.findElement(By.xpath("//div[contains(@id,'ClinvarWidgetPanel')]//span[text()='Search']")).click();
+    config.submit(driver, "cb-submit-button");
     config.sleep(driver);
     driver.wait(until.elementLocated(By.xpath("//div[contains(@id,'clinvar-browser-grid-body')]//table[2]//td[1]/div[text()]")), config.wait()).then(function(text) {
         driver.findElement(By.xpath("//div[contains(@id,'clinvar-browser-grid-body')]//table[2]//td[1]/div[text()]")).getText().then(function(text){
@@ -189,7 +189,7 @@ function clinVarSearchByTrait(driver){
     driver.findElement(By.name("gene")).sendKeys("BRCA1");
     driver.findElement(By.name("phenotype")).clear();
     driver.findElement(By.name("phenotype")).sendKeys("Pancreatic cancer");
-    driver.findElement(By.xpath("//div[contains(@id,'ClinvarWidgetPanel')]//span[text()='Search']")).click();
+    config.submit(driver, "cb-submit-button");
     config.sleep(driver);
     driver.wait(until.elementLocated(By.xpath("//div[contains(@id,'clinvar-browser-grid-body')]//table[2]//td[6]/div[text()]")), config.wait()).then(function(text) {
         driver.findElement(By.xpath("//div[contains(@id,'clinvar-browser-grid-body')]//table[2]//td[6]/div[text()]")).getText().then(function(text){
@@ -203,7 +203,7 @@ function clinVarSearchByTrait(driver){
 
 function clinVarFilterByConseqType(driver){
     driver.findElement(By.xpath("//div[contains(@class,'x-tree-view')]//span[contains(text(),'inframe_deletion')]//..//..//div[@role='button']")).click();
-    driver.findElement(By.xpath("//div[contains(@id,'ClinvarWidgetPanel')]//span[text()='Search']")).click();
+    config.submit(driver, "cb-submit-button");
     config.sleep(driver);
     driver.wait(until.elementLocated(By.xpath("//div[contains(@id,'clinvar-browser-grid-body')]//table[2]//td[5]/div/tpl[text()]")), config.wait()).then(function(text) {
         value = driver.findElement(By.xpath("//div[contains(@id,'clinvar-browser-grid-body')]//table[2]//td[5]/div/tpl[text()]")).getText().then(function(text){
@@ -218,7 +218,7 @@ function clinVarFilterByConseqType(driver){
 function clinVarFilterByVariationType(driver){
     driver.findElement(By.xpath("//div[contains(@id,'ClinvarWidgetPanel')]//span[text()='Reset']")).click();
     driver.findElement(By.xpath("//div[contains(@class,'x-tree-view')]//span[contains(text(),'Deletion')]//..//..//div[@role='button']")).click();
-    driver.findElement(By.xpath("//div[contains(@id,'ClinvarWidgetPanel')]//span[text()='Search']")).click();
+    config.submit(driver, "cb-submit-button");
     config.sleep(driver);
     driver.wait(until.elementLocated(By.xpath("//div[contains(@id,'clinvar-browser-grid-body')]//table[2]//td[1]/div[text()]")), config.wait()).then(function(text) {
         driver.wait(until.elementLocated(By.className("clinvar-variationType"))).then(function(text) {
@@ -233,7 +233,7 @@ function clinVarFilterByVariationType(driver){
 function clinVarFilterByClincalSignificance(driver){
     driver.findElement(By.xpath("//div[contains(@id,'ClinvarWidgetPanel')]//span[text()='Reset']")).click();
     driver.findElement(By.xpath("//div[contains(@class,'x-tree-view')]//span[contains(text(),'Uncertain significance')]//..//..//div[@role='button']")).click();
-    driver.findElement(By.xpath("//div[contains(@id,'ClinvarWidgetPanel')]//span[text()='Search']")).click();
+    config.submit(driver, "cb-submit-button");
     config.sleep(driver);
     driver.wait(until.elementLocated(By.xpath("//div[contains(@id,'clinvar-browser-grid-body')]//table[2]//td[7]/div[text()]")), config.wait()).then(function(text) {
         driver.findElement(By.xpath("//div[contains(@id,'clinvar-browser-grid-body')]//table[2]//td[7]/div[text()]")).getText().then(function(text){
@@ -246,7 +246,7 @@ function clinVarFilterByClincalSignificance(driver){
 function clinVarFilterByReviewStatus(driver){
     driver.findElement(By.xpath("//div[contains(@id,'ClinvarWidgetPanel')]//span[text()='Reset']")).click();
     driver.findElement(By.xpath("//div[contains(@class,'x-tree-view')]//span[contains(text(),'Expert panel')]//..//..//div[@role='button']")).click();
-    driver.findElement(By.xpath("//div[contains(@id,'ClinvarWidgetPanel')]//span[text()='Search']")).click();
+    config.submit(driver, "cb-submit-button");
     config.sleep(driver);
     driver.wait(until.elementLocated(By.xpath("//div[contains(@id,'clinvar-browser-grid-body')]//table[2]//td[1]/div[text()]")), config.wait()).then(function(text) {
         driver.wait(until.elementLocated(By.xpath("//div[contains(@id,'ClinVarSummaryDataPanel')]//table//td[@class='clinvar-reviewStatus']")), config.wait()).then(function(text) {
@@ -265,7 +265,7 @@ function showDataInVariantBrowser(driver){
     driver.findElement(By.xpath("//li[text()='Chromosomal Location']")).click();
     driver.findElement(By.name("clinvarRegion")).clear();
     driver.findElement(By.name("clinvarRegion")).sendKeys("13:32889611-32973805");
-    driver.findElement(By.xpath("//div[contains(@id,'ClinvarWidgetPanel')]//span[text()='Search']")).click();
+    config.submit(driver, "cb-submit-button");
     config.sleep(driver);
     driver.wait(until.elementLocated(By.xpath("//div[contains(@id,'clinvar-browser-grid-body')]//table[1]//td[1]/div[text()]")), config.wait()).then(function(text) {
         driver.findElement(By.id("variantBrw-button")).click();

--- a/tests/acceptance/clinical_browser.js
+++ b/tests/acceptance/clinical_browser.js
@@ -117,7 +117,7 @@ function clinVarSearchByAccession(driver){
     driver.findElement(By.xpath("//li[text()='ClinVar Accession']")).click();
     driver.findElement(By.name("accessionId")).clear();
     driver.findElement(By.name("accessionId")).sendKeys("RCV000074666");
-    driver.findElement(By.xpath("//div[contains(@id,'ClinvarWidgetPanel')]//span[text()='Submit']")).click();
+    driver.findElement(By.xpath("//div[contains(@id,'ClinvarWidgetPanel')]//span[text()='Search']")).click();
     config.sleep(driver);
     driver.wait(until.elementLocated(By.xpath("//div[contains(@id,'clinvar-browser-grid-body')]//table[1]//td[8]/div/a[text()]")), config.wait()).then(function(text) {
         driver.findElement(By.xpath("//div[contains(@id,'clinvar-browser-grid-body')]//table[1]//td[8]/div/a[text()]")).getText().then(function(text){
@@ -142,7 +142,7 @@ function clinVarSearchByLocation(driver){
     driver.findElement(By.xpath("//li[text()='Chromosomal Location']")).click();
     driver.findElement(By.name("clinvarRegion")).clear();
     driver.findElement(By.name("clinvarRegion")).sendKeys("13:32889611-32973805");
-    driver.findElement(By.xpath("//div[contains(@id,'ClinvarWidgetPanel')]//span[text()='Submit']")).click();
+    driver.findElement(By.xpath("//div[contains(@id,'ClinvarWidgetPanel')]//span[text()='Search']")).click();
     config.sleep(driver);
     driver.wait(until.elementLocated(By.xpath("//div[contains(@id,'clinvar-browser-grid-body')]//table[2]//td[1]/div[text()]")), config.wait()).then(function(text) {
         driver.findElement(By.xpath("//div[contains(@id,'clinvar-browser-grid-body')]//table[2]//td[1]/div[text()]")).getText().then(function(text){
@@ -164,7 +164,7 @@ function clinVarSearchByGene(driver){
     driver.findElement(By.xpath("//li[text()='Ensembl Gene Symbol/Accession']")).click();
     driver.findElement(By.name("gene")).clear();
     driver.findElement(By.name("gene")).sendKeys("BRCA1");
-    driver.findElement(By.xpath("//div[contains(@id,'ClinvarWidgetPanel')]//span[text()='Submit']")).click();
+    driver.findElement(By.xpath("//div[contains(@id,'ClinvarWidgetPanel')]//span[text()='Search']")).click();
     config.sleep(driver);
     driver.wait(until.elementLocated(By.xpath("//div[contains(@id,'clinvar-browser-grid-body')]//table[2]//td[1]/div[text()]")), config.wait()).then(function(text) {
         driver.findElement(By.xpath("//div[contains(@id,'clinvar-browser-grid-body')]//table[2]//td[1]/div[text()]")).getText().then(function(text){
@@ -189,7 +189,7 @@ function clinVarSearchByTrait(driver){
     driver.findElement(By.name("gene")).sendKeys("BRCA1");
     driver.findElement(By.name("phenotype")).clear();
     driver.findElement(By.name("phenotype")).sendKeys("Pancreatic cancer");
-    driver.findElement(By.xpath("//div[contains(@id,'ClinvarWidgetPanel')]//span[text()='Submit']")).click();
+    driver.findElement(By.xpath("//div[contains(@id,'ClinvarWidgetPanel')]//span[text()='Search']")).click();
     config.sleep(driver);
     driver.wait(until.elementLocated(By.xpath("//div[contains(@id,'clinvar-browser-grid-body')]//table[2]//td[6]/div[text()]")), config.wait()).then(function(text) {
         driver.findElement(By.xpath("//div[contains(@id,'clinvar-browser-grid-body')]//table[2]//td[6]/div[text()]")).getText().then(function(text){
@@ -203,7 +203,7 @@ function clinVarSearchByTrait(driver){
 
 function clinVarFilterByConseqType(driver){
     driver.findElement(By.xpath("//div[contains(@class,'x-tree-view')]//span[contains(text(),'inframe_deletion')]//..//..//div[@role='button']")).click();
-    driver.findElement(By.xpath("//div[contains(@id,'ClinvarWidgetPanel')]//span[text()='Submit']")).click();
+    driver.findElement(By.xpath("//div[contains(@id,'ClinvarWidgetPanel')]//span[text()='Search']")).click();
     config.sleep(driver);
     driver.wait(until.elementLocated(By.xpath("//div[contains(@id,'clinvar-browser-grid-body')]//table[2]//td[5]/div/tpl[text()]")), config.wait()).then(function(text) {
         value = driver.findElement(By.xpath("//div[contains(@id,'clinvar-browser-grid-body')]//table[2]//td[5]/div/tpl[text()]")).getText().then(function(text){
@@ -218,7 +218,7 @@ function clinVarFilterByConseqType(driver){
 function clinVarFilterByVariationType(driver){
     driver.findElement(By.xpath("//div[contains(@id,'ClinvarWidgetPanel')]//span[text()='Reset']")).click();
     driver.findElement(By.xpath("//div[contains(@class,'x-tree-view')]//span[contains(text(),'Deletion')]//..//..//div[@role='button']")).click();
-    driver.findElement(By.xpath("//div[contains(@id,'ClinvarWidgetPanel')]//span[text()='Submit']")).click();
+    driver.findElement(By.xpath("//div[contains(@id,'ClinvarWidgetPanel')]//span[text()='Search']")).click();
     config.sleep(driver);
     driver.wait(until.elementLocated(By.xpath("//div[contains(@id,'clinvar-browser-grid-body')]//table[2]//td[1]/div[text()]")), config.wait()).then(function(text) {
         driver.wait(until.elementLocated(By.className("clinvar-variationType"))).then(function(text) {
@@ -233,7 +233,7 @@ function clinVarFilterByVariationType(driver){
 function clinVarFilterByClincalSignificance(driver){
     driver.findElement(By.xpath("//div[contains(@id,'ClinvarWidgetPanel')]//span[text()='Reset']")).click();
     driver.findElement(By.xpath("//div[contains(@class,'x-tree-view')]//span[contains(text(),'Uncertain significance')]//..//..//div[@role='button']")).click();
-    driver.findElement(By.xpath("//div[contains(@id,'ClinvarWidgetPanel')]//span[text()='Submit']")).click();
+    driver.findElement(By.xpath("//div[contains(@id,'ClinvarWidgetPanel')]//span[text()='Search']")).click();
     config.sleep(driver);
     driver.wait(until.elementLocated(By.xpath("//div[contains(@id,'clinvar-browser-grid-body')]//table[2]//td[7]/div[text()]")), config.wait()).then(function(text) {
         driver.findElement(By.xpath("//div[contains(@id,'clinvar-browser-grid-body')]//table[2]//td[7]/div[text()]")).getText().then(function(text){
@@ -246,7 +246,7 @@ function clinVarFilterByClincalSignificance(driver){
 function clinVarFilterByReviewStatus(driver){
     driver.findElement(By.xpath("//div[contains(@id,'ClinvarWidgetPanel')]//span[text()='Reset']")).click();
     driver.findElement(By.xpath("//div[contains(@class,'x-tree-view')]//span[contains(text(),'Expert panel')]//..//..//div[@role='button']")).click();
-    driver.findElement(By.xpath("//div[contains(@id,'ClinvarWidgetPanel')]//span[text()='Submit']")).click();
+    driver.findElement(By.xpath("//div[contains(@id,'ClinvarWidgetPanel')]//span[text()='Search']")).click();
     config.sleep(driver);
     driver.wait(until.elementLocated(By.xpath("//div[contains(@id,'clinvar-browser-grid-body')]//table[2]//td[1]/div[text()]")), config.wait()).then(function(text) {
         driver.wait(until.elementLocated(By.xpath("//div[contains(@id,'ClinVarSummaryDataPanel')]//table//td[@class='clinvar-reviewStatus']")), config.wait()).then(function(text) {
@@ -265,7 +265,7 @@ function showDataInVariantBrowser(driver){
     driver.findElement(By.xpath("//li[text()='Chromosomal Location']")).click();
     driver.findElement(By.name("clinvarRegion")).clear();
     driver.findElement(By.name("clinvarRegion")).sendKeys("13:32889611-32973805");
-    driver.findElement(By.xpath("//div[contains(@id,'ClinvarWidgetPanel')]//span[text()='Submit']")).click();
+    driver.findElement(By.xpath("//div[contains(@id,'ClinvarWidgetPanel')]//span[text()='Search']")).click();
     config.sleep(driver);
     driver.wait(until.elementLocated(By.xpath("//div[contains(@id,'clinvar-browser-grid-body')]//table[1]//td[1]/div[text()]")), config.wait()).then(function(text) {
         driver.findElement(By.id("variantBrw-button")).click();

--- a/tests/acceptance/config-manager.js
+++ b/tests/acceptance/config-manager.js
@@ -70,6 +70,10 @@ module.exports = {
         driver.findElement(By.xpath("//span[text()='Search']")).click();
         return driver;
     },
+    submit:function (driver, submitButtonId){
+        driver.findElement(By.id(submitButtonId)).click();
+        return driver;
+    },
     back:function(){
         driver.navigate().back();
         return driver;

--- a/tests/acceptance/config-manager.js
+++ b/tests/acceptance/config-manager.js
@@ -67,7 +67,7 @@ module.exports = {
         return driver;
     },
     submit:function (driver){
-        driver.findElement(By.xpath("//span[text()='Submit']")).click();
+        driver.findElement(By.xpath("//span[text()='Search']")).click();
         return driver;
     },
     back:function(){

--- a/tests/acceptance/config-manager.js
+++ b/tests/acceptance/config-manager.js
@@ -66,10 +66,6 @@ module.exports = {
         driver.findElement(By.xpath("//span[text()='Reset']")).click();
         return driver;
     },
-    submit:function (driver){
-        driver.findElement(By.xpath("//span[text()='Search']")).click();
-        return driver;
-    },
     submit:function (driver, submitButtonId){
         driver.findElement(By.id(submitButtonId)).click();
         return driver;

--- a/tests/acceptance/study_browser.js
+++ b/tests/acceptance/study_browser.js
@@ -92,7 +92,7 @@ function sgvStudySearchBySpeciesType(driver){
     driver.findElement(By.xpath("//div[contains(@id,'GenomeSpeciesFilterFormPanel')]//div[@class='x-tool-img x-tool-collapse-top']")).click();
     driver.findElement(By.xpath("//div[contains(@class,'x-tree-view')]//span[contains(text(),'Exome Sequencing')]//..//..//div[@role='button']")).click();
     driver.findElement(By.xpath("//div[contains(@id,'GenomeSpeciesFilterFormPanel')]//div[@class='x-tool-img x-tool-expand-bottom']")).click();
-    config.submit(driver);
+    config.submit(driver, "study-submit-button");
     config.sleep(driver);
     driver.wait(until.elementLocated(By.xpath("//div[@id='study-browser-grid']//table[2]//td[4]/div[text()]")), config.wait()).then(function(text) {
         driver.findElement(By.xpath("//div[@id='study-browser-grid']//div[contains(@id,'_pagingToolbar-targetEl')]//div[contains(text(), 'Studies 1 -')]")).getText().then(function(text) {
@@ -117,7 +117,7 @@ function sgvStudySearchByType(driver){
     driver.findElement(By.xpath("//div[contains(@id,'GenomeSpeciesFilterFormPanel')]//div[@class='x-tool-img x-tool-collapse-top']")).click();
     driver.findElement(By.xpath("//div[contains(@class,'x-tree-view')]//span[contains(text(),'Curation')]//..//..//div[@role='button']")).click();
     driver.findElement(By.xpath("//div[contains(@id,'GenomeSpeciesFilterFormPanel')]//div[@class='x-tool-img x-tool-expand-bottom']")).click();
-    config.submit(driver);
+    config.submit(driver, "study-submit-button");
     config.sleep(driver);
     driver.wait(until.elementLocated(By.xpath("//div[@id='study-browser-grid']//table[2]//td[4]/div[text()]")), config.wait()).then(function(text) {
         driver.findElement(By.xpath("//div[@id='study-browser-grid']//div[contains(@id,'_pagingToolbar-targetEl')]//div[contains(text(), 'Studies 1 -')]")).getText().then(function(text) {
@@ -135,7 +135,7 @@ function sgvStudySearchByType(driver){
 
 function sgvStudySearchBySpecies(driver){
     driver.findElement(By.xpath("//span[contains(text(),'Barley')]//..//..//div[@role='button']")).click();
-    config.submit(driver);
+    config.submit(driver, "study-submit-button");
     config.sleep(driver);
     driver.wait(until.elementLocated(By.xpath("//div[@id='study-browser-grid']//table[1]//td[4]/div[text()]")), config.wait()).then(function(text) {
         driver.findElement(By.xpath("//div[@id='study-browser-grid']//div[contains(@id,'_pagingToolbar-targetEl')]//div[contains(text(), 'Studies 1 -')]")).getText().then(function(text) {
@@ -160,7 +160,7 @@ function svStudySearchBySpeciesType(driver){
     driver.findElement(By.xpath("//div[contains(@id,'GenomeSpeciesFilterFormPanel')]//div[@class='x-tool-img x-tool-collapse-top']")).click();
     driver.findElement(By.xpath("//span[contains(text(),'Control Set')]//..//..//div[@role='button']")).click();
     driver.findElement(By.xpath("//div[contains(@id,'GenomeSpeciesFilterFormPanel')]//div[@class='x-tool-img x-tool-expand-bottom']")).click();
-    config.submit(driver);
+    config.submit(driver, "study-submit-button");
     config.sleep(driver);
     driver.wait(until.elementLocated(By.xpath("//div[@id='study-browser-grid-body']//table[1]//td[4]/div/div[text()]")), config.wait()).then(function(text) {
         driver.findElement(By.xpath("//div[@id='study-browser-grid']//div[contains(@id,'_pagingToolbar-targetEl')]//div[contains(text(), 'Studies 1 -')]")).getText().then(function(text) {
@@ -186,7 +186,7 @@ function svStudySearchByType(driver){
     driver.findElement(By.xpath("//div[contains(@id,'GenomeSpeciesFilterFormPanel')]//div[@class='x-tool-img x-tool-collapse-top']")).click();
     driver.findElement(By.xpath("//span[contains(text(),'Control Set')]//..//..//div[@role='button']")).click();
     driver.findElement(By.xpath("//div[contains(@id,'GenomeSpeciesFilterFormPanel')]//div[@class='x-tool-img x-tool-expand-bottom']")).click();
-    config.submit(driver);
+    config.submit(driver, "study-submit-button");
     config.sleep(driver);
     driver.wait(until.elementLocated(By.xpath("//div[@id='study-browser-grid-body']//table[1]//td[4]/div/div[text()]")), config.wait()).then(function(text) {
         driver.findElement(By.xpath("//div[@id='study-browser-grid']//div[contains(@id,'_pagingToolbar-targetEl')]//div[contains(text(), 'Studies 1 -')]")).getText().then(function(text) {
@@ -207,7 +207,7 @@ function svStudySearchBySpecies(driver){
     driver.findElement(By.xpath("//label[@id='sv-boxLabelEl']")).click();
     driver.findElement(By.xpath("//span[contains(text(),'Chimpanzee')]//..//..//div[@role='button']")).click();
     driver.findElement(By.xpath("//span[contains(text(),'Dog')]//..//..//div[@role='button']")).click();
-    config.submit(driver);
+    config.submit(driver, "study-submit-button");
     config.sleep(driver);
     driver.wait(until.elementLocated(By.xpath("//div[@id='study-browser-grid-body']//table[1]//td[4]/div/div[text()]")), config.wait()).then(function(text) {
         driver.findElement(By.xpath("//div[@id='study-browser-grid']//div[contains(@id,'_pagingToolbar-targetEl')]//div[contains(text(), 'Studies 1 -')]")).getText().then(function(text) {
@@ -229,7 +229,7 @@ function sgvStudySearchByText(driver){
     config.reset(driver);
     driver.findElement(By.name("search")).clear();
     driver.findElement(By.name("search")).sendKeys("1000");
-    config.submit(driver);
+    config.submit(driver, "study-submit-button");
     config.sleep(driver);
     driver.wait(until.elementLocated(By.xpath("//div[@id='study-browser-grid']//table[1]//td[3]/div[text()]")), config.wait()).then(function(text) {
         var regex =   new RegExp('1000', 'g');
@@ -248,7 +248,7 @@ function svStudySearchByText(driver){
     driver.findElement(By.xpath("//label[@id='sv-boxLabelEl']")).click();
     driver.findElement(By.name("search")).clear();
     driver.findElement(By.name("search")).sendKeys("1000");
-    config.submit(driver);
+    config.submit(driver, "study-submit-button");
     config.sleep(driver);
     driver.wait(until.elementLocated(By.xpath("//div[@id='study-browser-grid']//table[1]//td[3]/div[text()]")), config.wait()).then(function(text) {
         var regex =   new RegExp('1000', 'g');

--- a/tests/acceptance/study_view.js
+++ b/tests/acceptance/study_view.js
@@ -63,7 +63,7 @@ test.describe('Study View ('+config.browser()+')', function() {
         test.it('Check Summary Table Values are not empty', function() {
             driver.wait(until.elementLocated(By.xpath("//div[@id='study-browser-grid-body']//table[2]//td[2]/div/a")), config.wait()).then(function(text) {
                 driver.findElement(By.xpath("//label[@id='sv-boxLabelEl']")).click();
-                config.submit(driver);
+                config.submit(driver, "study-submit-button");
                 driver.wait(until.elementLocated(By.xpath("//div[@id='study-browser-grid-body']//table[2]//td[2]/div/a")), config.wait()).then(function(text) {
                     driver.findElement(By.xpath("//div[@id='study-browser-grid-panel-body']//div[contains(@id,'_pagingToolbar-targetEl')]//div[contains(text(), 'Studies 1 -')]")).getText().then(function(text) {
                         var rows = parseInt(text.split(" ")[3]);


### PR DESCRIPTION
In order to make more clear the intention of the search forms, the 'Submit' text has been replaced with 'Search' in the following pages:

* Study browser
* Variant browser
* Clinical browser
* GA4GH beacon