### PR TITLE
Fix travis builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,17 @@ After successful build the files are then copied to a folder of the form _eva-we
  
  grunt  
  ```
+
+
+## Testing
+
+Currently we build and run tests using [travis](https://travis-ci.org/EBIvariation/eva-web/branches).
+
+### Test design
+
+We use Mocha as test framework and Chai as test assertion library. The tests are run as grunt tasks. We use a specific version of firefox to run those tests in travis (look at .travis.yml to see which specific version). There are 2 types of tests, acceptance and unitary.
+
+### When a test fails
+
+As the whole test suite takes some minutes to complete, you can run only some tests adding `grep "<substring of test description>"` (e.g. grep "Variant Browser") in gruntfile.js in the `mochaTest.acceptanceTest.options` object, and run as `env BROWSER=firefox grunt --env=staging mochaTest:acceptanceTest`.
+

--- a/README.md
+++ b/README.md
@@ -78,11 +78,11 @@ After successful build the files are then copied to a folder of the form _eva-we
 
 ## Testing
 
-Currently we build and run tests using [travis](https://travis-ci.org/EBIvariation/eva-web/branches).
+Currently we build and run tests using [Travis CI](https://travis-ci.org/EBIvariation/eva-web/branches).
 
 ### Test design
 
-We use Mocha as test framework and Chai as test assertion library. The tests are run as grunt tasks. We use a specific version of firefox to run those tests in travis (look at .travis.yml to see which specific version). There are 2 types of tests, acceptance and unitary.
+We use Mocha as test framework and Chai as test assertion library. The tests are run as Grunt tasks. We use a specific version of Firefox to run those tests in Travis CI (look at .travis.yml to see which specific version). There are acceptance tests and unit tests.
 
 ### When a test fails
 

--- a/tests/acceptance/study_browser.js
+++ b/tests/acceptance/study_browser.js
@@ -124,7 +124,8 @@ function sgvStudySearchByType(driver){
             var rows = parseInt(text.split(" ")[3]);
             for (i = 1; i <= rows; i++) {
                 type = driver.findElement(By.xpath("//div[@id='study-browser-grid']//table["+i+"]//td[6]/div/tpl[text()]")).getText();
-                assert(type).equalTo('Curation');
+                var typeRegex = new RegExp('.*Curation.*');
+                assert(type).matches(typeRegex);
             }
             return rows;
         });

--- a/tests/acceptance/variant_browser.js
+++ b/tests/acceptance/variant_browser.js
@@ -208,7 +208,7 @@ function checkdbSNPLink(driver){
     driver.wait(until.elementLocated(By.xpath("//div[@id='variant-browser-grid-body']//table[1]//td[1]/div[text()]")), config.wait()).then(function(text) {
         driver.findElement(By.xpath("//div[@id='variant-browser-grid-body']//table[1]//td[9]/div//a[contains(@class,'dbsnp_link')]")).getAttribute('href').then(function(text){
             driver.findElement(By.xpath("//div[@id='variant-browser-grid-body']//table[1]//td[3]/div[text()]")).getText().then(function(variantID){
-                assert(text).equalTo('http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ss.cgi?subsnp_id='+variantID.substring(2));
+                assert(text).equalTo('http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?rs='+variantID);
             });
         });
     });


### PR DESCRIPTION
- one test assumed that in the ID column could appear subsnps. Currently only rs ids can appear there.
- Another one assumed that a study has only one type. This is not correct.
- Added a bit of information about the tests in the README.