### PR TITLE
EVA-1048 Fixed bug in visualization of variants with a single substitution score

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,7 +15,7 @@ module.exports = function (grunt) {
         // Metadata.
         meta: {
             version: {
-                eva: '3.9.1'
+                eva: '3.9.2'
             }
         },
         serve: {

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "eva-web",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "homepage": "https://github.com/EBIvariation/eva-web",
   "authors": [
     "EVA development team <eva-helpdesk@ebi.ac.uk>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commons",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "description": "javascript commons",
   "repository": {
     "type": "git",

--- a/src/js/variant-widget/eva-variant-browser-grid.js
+++ b/src/js/variant-widget/eva-variant-browser-grid.js
@@ -236,10 +236,10 @@ EvaVariantBrowserGrid.prototype = {
                     }
                     if(!successful) {
                         _this.grid.getView().emptyText = '<div class="x-grid-empty">Variants could not be retrieved due to an error</div>';
+                        _this.grid.getView().refresh();
                     }else{
                         _this.grid.getView().emptyText = '<div class="x-grid-empty">No records to display</div>';
                     }
-                    _this.grid.getView().refresh();
                     _this.setLoading(false);
                 },
                 beforeload: function (store, operation, eOpts) {

--- a/src/js/variant-widget/eva-variant-widget.js
+++ b/src/js/variant-widget/eva-variant-widget.js
@@ -1133,7 +1133,6 @@ function getProteinSubstitutionScore(consequenceTypes,so_array,source) {
                 _.each(_.keys(consequenceTypes[i].proteinSubstitutionScores), function (key) {
                     var source_scores = _.findWhere(this, {source: source})
                     if (source_scores !== undefined) {
-                        score = source_scores.score
                         score_array.push(source_scores.score)
                     }
                 }, consequenceTypes[i].proteinSubstitutionScores);

--- a/src/js/variant-widget/eva-variant-widget.js
+++ b/src/js/variant-widget/eva-variant-widget.js
@@ -249,7 +249,6 @@ EvaVariantWidget.prototype = {
     },
     _createVariantBrowserGrid: function (target) {
         var _this = this;
-
         var columns = {
             items: [
                 {
@@ -1132,8 +1131,11 @@ function getProteinSubstitutionScore(consequenceTypes,so_array,source) {
         for (var j = 0; j < consequenceTypes[i].soTerms.length; j++) {
             if (consequenceTypes[i].soTerms[j].soName == _.first(so_array)) {
                 _.each(_.keys(consequenceTypes[i].proteinSubstitutionScores), function (key) {
-                    score = _.findWhere(this, {source: source}).score
-                    score_array.push(_.findWhere(this, {source: source}).score)
+                    var source_scores = _.findWhere(this, {source: source})
+                    if (source_scores !== undefined) {
+                        score = source_scores.score
+                        score_array.push(source_scores.score)
+                    }
                 }, consequenceTypes[i].proteinSubstitutionScores);
             }
         }

--- a/tests/unit/variant_browser.js
+++ b/tests/unit/variant_browser.js
@@ -103,7 +103,7 @@ describe('Protein Substitution Score Tests', function(){
             ]
 
         }];
-    it('check Polyphen Score should be equal to 0.961', function(){
+    it('check Polyphen Score should be equal to 0.981', function(){
         var so_array = getMostSevereConsequenceType(testObjectBefore);
         expect(getProteinSubstitutionScore(testObjectBefore,so_array,'Polyphen')).to.deep.equal(0.981);
     });
@@ -111,6 +111,106 @@ describe('Protein Substitution Score Tests', function(){
         var so_array = getMostSevereConsequenceType(testObjectBefore);
         expect(getProteinSubstitutionScore(testObjectBefore,so_array,'Sift')).to.deep.equal(0.2);
     });
+
+    var noSiftTestObject = [{
+        soTerms: [
+            {
+                soName: "stop_lost",
+                soAccession: "SO:0001623"
+            }
+        ],
+        proteinSubstitutionScores: [
+            {
+                score: 0.961,
+                source: "Polyphen",
+                description: "probably_damaging"
+            }
+        ]
+    },
+        {
+            soTerms: [
+                {
+                    soName: "stop_lost",
+                    soAccession: "SO:0001623"
+                }
+            ],
+            proteinSubstitutionScores: [
+                {
+                    score: 0.981,
+                    source: "Polyphen",
+                    description: "probably_damaging"
+                }
+            ]
+
+        }];
+
+    it('If there are Polyphen but no Sift Scores, "-" should be returned as maximum Sift score', function(){
+        var so_array = getMostSevereConsequenceType(noSiftTestObject);
+        expect(getProteinSubstitutionScore(noSiftTestObject,so_array,'Polyphen')).to.deep.equal(0.981);
+        expect(getProteinSubstitutionScore(noSiftTestObject,so_array,'Sift')).to.deep.equal('-');
+    });
+
+    var noPolyphenTestObject = [{
+        soTerms: [
+            {
+                soName: "stop_lost",
+                soAccession: "SO:0001623"
+            }
+        ],
+        proteinSubstitutionScores: [
+            {
+                score: 0.3,
+                source: "Sift",
+                description: "deleterious"
+            }
+        ]
+    },
+        {
+            soTerms: [
+                {
+                    soName: "stop_lost",
+                    soAccession: "SO:0001623"
+                }
+            ],
+            proteinSubstitutionScores: [
+                {
+                    score: 0.2,
+                    source: "Sift",
+                    description: "deleterious"
+                }
+            ]
+
+        }];
+    it('If there are Sift but no Polyphen Scores, "-" should be returned as maximum Polyphen score', function(){
+        var so_array = getMostSevereConsequenceType(noPolyphenTestObject);
+        expect(getProteinSubstitutionScore(noPolyphenTestObject,so_array,'Polyphen')).to.deep.equal('-');
+        expect(getProteinSubstitutionScore(noPolyphenTestObject,so_array,'Sift')).to.deep.equal(0.2);
+    });
+
+    var noProteinSubstitutionScoresTestObject = [{
+        soTerms: [
+            {
+                soName: "stop_lost",
+                soAccession: "SO:0001623"
+            }
+        ]
+    },
+        {
+            soTerms: [
+                {
+                    soName: "stop_lost",
+                    soAccession: "SO:0001623"
+                }
+            ]
+
+        }];
+    it('If there are no protein substitution Scores, "-" should be returned as maximum Polyphen and Sit scores', function(){
+        var so_array = getMostSevereConsequenceType(noProteinSubstitutionScoresTestObject);
+        expect(getProteinSubstitutionScore(noProteinSubstitutionScoresTestObject,so_array,'Polyphen')).to.deep.equal('-');
+        expect(getProteinSubstitutionScore(noProteinSubstitutionScoresTestObject,so_array,'Sift')).to.deep.equal('-');
+    });
+
+
 });
 
 describe('Consequence Type Tree', function(){


### PR DESCRIPTION
The function _findWhere returns undefined if a score for a source (sift or polyphen) is not found. The call to '.score' over that undefined object was causing the function terminating abruptly without returning any score. This has been fixed, storing the result of _findWhere in a local variable and checking if is undefined before accessing its attributes.