### PR TITLE
Fixed bug introduced in the last commit

### DIFF
--- a/src/js/variant-widget/eva-variant-browser-grid.js
+++ b/src/js/variant-widget/eva-variant-browser-grid.js
@@ -236,9 +236,11 @@ EvaVariantBrowserGrid.prototype = {
                     }
                     if(!successful) {
                         _this.grid.getView().emptyText = '<div class="x-grid-empty">Variants could not be retrieved due to an error</div>';
-                        _this.grid.getView().refresh();
                     }else{
                         _this.grid.getView().emptyText = '<div class="x-grid-empty">No records to display</div>';
+                    }
+                    if (records.length === 0) {
+                        _this.grid.getView().refresh();
                     }
                     _this.setLoading(false);
                 },


### PR DESCRIPTION
After an erroneous call in the variant search, a correct call with no results was no refreshing the screen, and the error message was not being replaced by a 'No variants to display' one