### PR TITLE
EVA-1219 GDPR privacy notices on website and submissions

### DIFF
--- a/tests/acceptance/config-manager.js
+++ b/tests/acceptance/config-manager.js
@@ -35,6 +35,7 @@ module.exports = {
         driver.get(baseURL);
         chai.use(chaiWebdriver(driver));
         driver.wait(until.elementLocated(By.id("cookie-dismiss")), 10000).then(function(text) {
+            driver.findElement(By.xpath("//*[@id='data-protection-agree']")).click();
             driver.findElement(By.xpath("//div[@id='cookie-dismiss']//button[@class='close-button']")).click();
         });
         return driver;

--- a/tests/acceptance/variant_browser.js
+++ b/tests/acceptance/variant_browser.js
@@ -475,6 +475,7 @@ function variantFilterByMAF(driver){
 function checkAnnotationNotification(driver){
     driver.findElement(By.xpath("//span[text()='Reset']")).click();
     driver.findElement(By.id("speciesFilter-trigger-picker")).click();
+    driver.executeScript("arguments[0].scrollIntoView(true);", driver.findElement(By.xpath("//li[text()='Mosquito / AaegL3']")));
     driver.findElement(By.xpath("//li[text()='Mosquito / AaegL3']")).click();
     driver.findElement(By.id("annotVersion-trigger-picker")).click();
     driver.findElement(By.xpath("//li[text()='VEP version 89 - Cache version 35']")).click();


### PR DESCRIPTION
Added click action on data protection banner for automated tests

We are leaving this line `driver.findElement(By.xpath("//div[@id='cookie-dismiss']//button[@class='close-button']")).click();` because the old banner is still shown in the web site after the new banner is dismissed.