### PR TITLE
EVA-1226 Address dbSNP import progress report usability issues

### DIFF
--- a/src/css/eva.css
+++ b/src/css/eva.css
@@ -761,3 +761,9 @@ table.tablesorter thead tr th.tablesorter-headerDesc{
 .img-format {
     text-align: center;
 }
+.percentage-indicator {
+    color: #3fa8a8; 
+    font-size: 120%; 
+    font-weight: bold;
+    margin-bottom: 0px;
+}

--- a/src/index.html
+++ b/src/index.html
@@ -938,7 +938,7 @@
                                                 <a class="accordion-title"><h5>Will there be EVA builds or releases like the dbSNP ones?</h5></a>
                                                 <div class="accordion-content" data-tab-content>
                                                     <p>
-                                                        Yes. The EVA will create RefSNP dumps in VCF format every 6 months, starting in Q2 2018. These dumps shall contain the most basic information about each RefSNP:
+                                                        Yes. The EVA will create RefSNP dumps in VCF format every 6 months, starting in Q3 2018. These dumps shall contain the most basic information about each RefSNP:
                                                     </p>
                                                     <p>
                                                         <ul>

--- a/src/js/dbSNP-import/dbSNP-import-progress.js
+++ b/src/js/dbSNP-import/dbSNP-import-progress.js
@@ -81,17 +81,11 @@ EvadbSNPImportProgress.prototype = {
                     '<th rowspan="2">Taxonomy ID</th>' +
                     '<th rowspan="2">INSDC assembly accession</th>' +
                     '<th rowspan="2">dbSNP build</th>' +
-                    '<th colspan="3">Searchable by</th>' +
+                    '<th colspan="3" style="background-image:none;">Searchable by</th>' +
                 '</tr>' +
                 '<tr>' +
-                    '<th>' +
-                        '<div title="SS and RS IDs matching an assembly accessioned by INSDC, and reporting genotypes and/or frequencies">' +
-                            'Current IDs satisfying<br>submission requirements ' +
-                            '<i class="icon icon-generic" data-icon="i">' +
-                        '</div>' +
-                    '</th>' +
-                    '<th><div title="SS and RS IDs matching an assembly accessioned by INSDC">All current IDs <i class="icon icon-generic" data-icon="i"></div></th>' +
-                    '<th><dib title="RS IDs merged into others">Synonymous RS IDs <i class="icon icon-generic" data-icon="i"></div></th>' +
+                    '<th><div title="RS IDs and associated SS IDs available in the last dbSNP build for a species">Current RS IDs <i class="icon icon-generic" data-icon="i"></div></th>' +
+                    '<th><div title="RS IDs merged into others">Synonymous RS IDs <i class="icon icon-generic" data-icon="i"></div></th>' +
                 '</tr>' +
                 '</thead><tbody>';
 
@@ -108,11 +102,9 @@ EvadbSNPImportProgress.prototype = {
                 taxonomy_link = '<a target="_blank" href="https://www.ebi.ac.uk/ena/data/view/Taxon:'+this[key].taxId+'">'+this[key].taxId+'</a>';
             }
 
-            var variantsWithEvidenceImported = _this._getImportStatus(this[key].variantsWithEvidenceImported, this[key].variantsWithEvidenceImportedDate, '');
+            var importedIds = _this._getImportStatus(this[key].importedIds, this[key].totalIdsDbsnp);
 
-            var variantsImported = _this._getImportStatus(this[key].variantsImported, this[key].variantsImportedDate, '');
-
-            var rsSynonymsImported = _this._getImportStatus(this[key].rsSynonymsImported, this[key].rsSynonymsImportedDate,'');
+            var importedSynonymousIds = _this._getImportStatus(this[key].importedSynonymousIds, this[key].totalSynonymousIdsDbsnp);            
 
             table += '<tr>' +
                 '<td><span class="dbSNP-common-name">'+this[key].commonName+'</span></td>' +
@@ -120,40 +112,27 @@ EvadbSNPImportProgress.prototype = {
                 '<td><span class="dbSNP-tax-id">'+taxonomy_link+'</span></td>' +
                 '<td><span class="dbSNP-assembly-accession">'+genbankAssemblyAccession+'</span></td>' +
                 '<td><span class="dbSNP-build">'+this[key].lastDbsnpBuild+'</span></td>' +
-                '<td><span class="dbSNP-variants-with-evidence-imported">'+variantsWithEvidenceImported+'</span></td>' +
-                '<td><span class="dbSNP-variants-imported">'+variantsImported+'</span></td>' + 
-                '<td><span class="dbSNP-rs-imported">'+rsSynonymsImported+'</span></td>' +
+                '<td><span class="dbSNP-imported-ids">'+importedIds+'</span></td>' + 
+                '<td><span class="dbSNP-imported-synonymous-ids">'+importedSynonymousIds+'</span></td>' +
                 '</tr>';
         }, data);
         table += '</tbody></table></div></div>';
         return table;
     },
 
-    _getImportStatus : function (value,dateString,addLink){
-        var el;
-        var date = new Date(dateString);
-        switch(value) {
-            case 'pending':
-                el = '<p></p>';
-                break;
-            case 'in_progress':
-                el = '<h6>In progress</h6>';
-                break;
-            case 'done':
-                el = '<h5 class="icon icon-functional" data-icon="/"><span style="visibility: hidden;">Y</span></h5>'
-                    + '<h6>' + date.getDate() + "/" + (date.getMonth() +1) + "/" + date.getFullYear() + '</h6>';
-                break;
-            case true:
-                el = '<h5 class="icon icon-functional" data-icon="/"><span style="visibility: hidden;">Y</span></h5>';
-                break;
-            case false:
-                el = '<p></p>';
-                break;
-            default:
-                el = '<p><h5 class="icon icon-generic" data-icon="?"><span style="visibility: hidden;">?</span></p>';
+    _getImportStatus : function (importedIds,totalIds){
+        var indicator;
+        var percentage;
+        var progress;
+        if(importedIds && totalIds) {
+            totalIds != 0? percentage = Math.round((importedIds / totalIds) * 100) : percentage = 0;
+            progress =  importedIds + '/' + totalIds;
+        } else {
+            percentage = 0;
+            progress = '0/0';
         }
-
-        return el;
+        indicator = '<a title="' + progress + '" class="percentage-indicator">' + percentage + '%</a>';
+        return indicator;
     }
 
 }

--- a/src/js/dbSNP-import/dbSNP-import-progress.js
+++ b/src/js/dbSNP-import/dbSNP-import-progress.js
@@ -28,7 +28,7 @@ EvadbSNPImportProgress.prototype = {
     render: function () {
         var _this = this;
         _this._draw( _this._createContent());
-        $("#dbSNP-import-table").tablesorter();
+        $("#dbSNP-import-table").tablesorter({ sortList: [[5,1], [0,0]] });
         //sending tracking data to Google Analytics
         ga('send', 'event', { eventCategory: 'Views', eventAction: 'EvadbSNPImportProgress', eventLabel: 'EvadbSNPImportProgress'});
     },
@@ -89,7 +89,7 @@ EvadbSNPImportProgress.prototype = {
                 '</tr>' +
                 '</thead><tbody>';
 
-        data = _.sortBy(data, 'commonName');
+        //data = _.sortBy(data, 'importedIds', 'commonName');
         _.each (_.keys(data), function(key) {
             var genbankAssemblyAccession = '-';
             var taxonomy_link;
@@ -125,11 +125,13 @@ EvadbSNPImportProgress.prototype = {
         var percentage;
         var progress;
         if(importedIds && totalIds) {
-            totalIds != 0? percentage = Math.round((importedIds / totalIds) * 100) : percentage = 0;
-            progress =  importedIds + '/' + totalIds;
+            var progresValue = (importedIds / totalIds)*100;
+            var decimal = progresValue % 1 == 0? ',00' : (progresValue % 1).toString().substr(1,3).replace('.',',');
+            totalIds != 0? percentage = Math.trunc(progresValue) + decimal : percentage = 0;
+            progress = importedIds.toLocaleString().replace(/[,]+/g, '.') + ' / ' + totalIds.toLocaleString().replace(/[,]+/g, '.');
         } else {
-            percentage = 0;
-            progress = '0/0';
+            percentage = '0,00';
+            progress = '0 / 0';
         }
         indicator = '<a title="' + progress + '" class="percentage-indicator">' + percentage + '%</a>';
         return indicator;

--- a/src/js/dbSNP-import/dbSNP-import-progress.js
+++ b/src/js/dbSNP-import/dbSNP-import-progress.js
@@ -123,17 +123,19 @@ EvadbSNPImportProgress.prototype = {
     _getImportStatus : function (importedIds,totalIds){
         var indicator;
         var percentage;
+        var proportion;
         var progress;
         if(importedIds && totalIds) {
-            var progresValue = (importedIds / totalIds)*100;
-            var decimal = progresValue % 1 == 0? ',00' : (progresValue % 1).toString().substr(1,3).replace('.',',');
-            totalIds != 0? percentage = Math.trunc(progresValue) + decimal : percentage = 0;
-            progress = importedIds.toLocaleString().replace(/[,]+/g, '.') + ' / ' + totalIds.toLocaleString().replace(/[,]+/g, '.');
+            // truncate the proportion to 4 decimals, to be showed as a percentage with 2 decimals
+            proportion = Math.floor((importedIds / totalIds) * 10000) / 10000;
+            progress = importedIds.toLocaleString() + ' / ' + totalIds.toLocaleString();
         } else {
-            percentage = '0,00';
+            proportion = 0;
             progress = '0 / 0';
         }
-        indicator = '<a title="' + progress + '" class="percentage-indicator">' + percentage + '%</a>';
+        percentage = proportion.toLocaleString(undefined, {style: 'percent', maximumFractionDigits: 2});
+
+        indicator = '<a title="' + progress + '" class="percentage-indicator">' + percentage + '</a>';
         return indicator;
     }
 

--- a/tests/acceptance/dbSNP_import.js
+++ b/tests/acceptance/dbSNP_import.js
@@ -94,9 +94,9 @@ test.describe('dbSNP Import Progress ('+config.browser()+')', function() {
             });
         });
 
-        test.it('Check "Current dbSNP IDs supported by evidence searchable" column should not be empty', function() {
+        test.it('Check "Current RS IDs" column should not be empty', function() {
             driver.wait(until.elementLocated(By.id("dbSNP-import-table")), config.wait()).then(function(text) {
-                driver.findElements(By.className("dbSNP-variants-with-evidence-imported")).then(function(rows){
+                driver.findElements(By.className("dbSNP-imported-ids")).then(function(rows){
                     for (var i = 0; i < rows.length; i++){
                         rows[i].getAttribute("innerHTML").then(function(text){
                             chai.assert.notEqual(text, null);
@@ -106,33 +106,9 @@ test.describe('dbSNP Import Progress ('+config.browser()+')', function() {
             });
         });
 
-        test.it('Check "Current dbSNP IDs searchable" column should not be empty', function() {
+        test.it('Check "Synonymous RS IDs" column should not be empty', function() {
             driver.wait(until.elementLocated(By.id("dbSNP-import-table")), config.wait()).then(function(text) {
-                driver.findElements(By.className("dbSNP-variants-imported")).then(function(rows){
-                    for (var i = 0; i < rows.length; i++){
-                        rows[i].getAttribute("innerHTML").then(function(text){
-                            chai.assert.notEqual(text, null);
-                        });
-                    }
-                });
-            });
-        });
-
-        test.it('Check "Previous dbSNP accessions searchable" column should not be empty', function() {
-            driver.wait(until.elementLocated(By.id("dbSNP-import-table")), config.wait()).then(function(text) {
-                driver.findElements(By.className("dbSNP-rs-imported")).then(function(rows){
-                    for (var i = 0; i < rows.length; i++){
-                        rows[i].getAttribute("innerHTML").then(function(text){
-                            chai.assert.notEqual(text, null);
-                        });
-                    }
-                });
-            });
-        });
-
-        test.it('Check "Supported by Ensembl" column should not be empty', function() {
-            driver.wait(until.elementLocated(By.id("dbSNP-import-table")), config.wait()).then(function(text) {
-                driver.findElements(By.className("dbSNP-in-ensembl")).then(function(rows){
+                driver.findElements(By.className("dbSNP-imported-synonymous-ids")).then(function(rows){
                     for (var i = 0; i < rows.length; i++){
                         rows[i].getAttribute("innerHTML").then(function(text){
                             chai.assert.notEqual(text, null);


### PR DESCRIPTION
dbSNP Import Progress usability changes.

Columns deleted: `All variants match INSDC assembly`, `Suitable for Variant Browser`, `Current dbSNP accessions searchable`  

New Columns: `Current RS IDs`, `Synonymous RS IDs`