### PR TITLE
EVA-1219 GDPR privacy notice on website

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -240,7 +240,7 @@
 
                     <h3 class="padding-bottom-large">Key stages of EVA submissions</h3>
 
-                    <h4 name="submit-prepare"><span class="icon icon-generic" data-icon="'" aria-hidden="true"></span> Prepare</h4>
+                    <h4 id="submit-prepare"><span class="icon icon-generic" data-icon="'" aria-hidden="true"></span> Prepare</h4>
                     <div>
                         <p>
                             Submissions to the EVA consist of VCF file(s), any associated data file(s), and metadata that describe sample(s) and analysis that produced the variant and/or genotype call(s).
@@ -252,17 +252,17 @@
                         </p>
                     </div>
 
-                    <h4 name="submit-contact"><span class="icon icon-generic" data-icon="C" aria-hidden="true"></span> Contact</h4>
+                    <h4 id="submit-contact"><span class="icon icon-generic" data-icon="C" aria-hidden="true"></span> Contact</h4>
                     <div>
                         <p>Contact  <a href="mailto:eva-helpdesk@ebi.ac.uk" target="_top">eva-helpdesk@ebi.ac.uk</a> in order to provide details of your submission. You shall receive a custom private FTP location for you to deposit files.</p>
                     </div>
 
-                    <h4 name="submit-submit"><span class="icon icon-functional" data-icon="_"></span> Submit</h4>
+                    <h4 id="submit-submit"><span class="icon icon-functional" data-icon="_"></span> Submit</h4>
                     <div>
                         <p>Upload your VCF file(s), associated data file(s) and EVA metadata template to your private EVA FTP location.</p>
                     </div>
 
-                    <h4 name="submit-receive"><span class="icon icon-functional" data-icon="k" aria-hidden="true"></span> Receive</h4>
+                    <h4 id="submit-receive"><span class="icon icon-functional" data-icon="k" aria-hidden="true"></span> Receive</h4>
                     <div class="padding-bottom-large">
                       <p>The EVA aims to process submissions within two business days. Accession numbers shall be sent via email to the submitter upon successful archival of the deposited data.</p>
                     </div>

--- a/src/index.html
+++ b/src/index.html
@@ -243,8 +243,8 @@
                     <h4><span class="icon icon-generic" data-icon="'" aria-hidden="true"></span> Prepare</h4>
                     <div>
                         <p>
-                            Submissions to the EVA consist of VCF file(s), any associated data file(s), and metadata that describe sample(s), experiment(s), and analysis that produced the variant and/or genotype call(s).
-                            This metadata is described in an Excel template that can be found <a href="files/EVA_Submission_template.V1.1.1.xlsx">here</a>. Please also see <a href="files/EVA_Submission_template.V1.1.1_mockup.xlsx">here</a> for a mocked up version of this template that has been completed for a fictional study.
+                            Submissions to the EVA consist of VCF file(s), any associated data file(s), and metadata that describe sample(s) and analysis that produced the variant and/or genotype call(s).
+                            This metadata is described in an Excel template that can be found <a href="files/EVA_Submission_template.V1.1.1.xlsx">here</a>. Please also see <a href="files/EVA_Submission_template.V1.1.1_mockup.xlsx">here</a> for a mocked up version of this template that has been completed for a fictional study. Please note that the template requires the submitter to fill in some personal data, which will be used as described in <a href="https://www.ebi.ac.uk/data-protection/privacy-notice/eva-submission-service">our privacy notice</a>.
                         </p>
                         <p>
                             VCF file(s) submitted to the EVA must be truly valid a 4.X version of the file format <a href="http://samtools.github.io/hts-specs/VCFv4.3.pdf" target="_blank">specification</a>.

--- a/src/index.html
+++ b/src/index.html
@@ -240,7 +240,7 @@
 
                     <h3 class="padding-bottom-large">Key stages of EVA submissions</h3>
 
-                    <h4><span class="icon icon-generic" data-icon="'" aria-hidden="true"></span> Prepare</h4>
+                    <h4 name="submit-prepare"><span class="icon icon-generic" data-icon="'" aria-hidden="true"></span> Prepare</h4>
                     <div>
                         <p>
                             Submissions to the EVA consist of VCF file(s), any associated data file(s), and metadata that describe sample(s) and analysis that produced the variant and/or genotype call(s).
@@ -252,17 +252,17 @@
                         </p>
                     </div>
 
-                    <h4><span class="icon icon-generic" data-icon="C" aria-hidden="true"></span> Contact</h4>
+                    <h4 name="submit-contact"><span class="icon icon-generic" data-icon="C" aria-hidden="true"></span> Contact</h4>
                     <div>
                         <p>Contact  <a href="mailto:eva-helpdesk@ebi.ac.uk" target="_top">eva-helpdesk@ebi.ac.uk</a> in order to provide details of your submission. You shall receive a custom private FTP location for you to deposit files.</p>
                     </div>
 
-                    <h4><span class="icon icon-functional" data-icon="_"></span> Submit</h4>
+                    <h4 name="submit-submit"><span class="icon icon-functional" data-icon="_"></span> Submit</h4>
                     <div>
                         <p>Upload your VCF file(s), associated data file(s) and EVA metadata template to your private EVA FTP location.</p>
                     </div>
 
-                    <h4><span class="icon icon-functional" data-icon="k" aria-hidden="true"></span> Receive</h4>
+                    <h4 name="submit-receive"><span class="icon icon-functional" data-icon="k" aria-hidden="true"></span> Receive</h4>
                     <div class="padding-bottom-large">
                       <p>The EVA aims to process submissions within two business days. Accession numbers shall be sent via email to the submitter upon successful archival of the deposited data.</p>
                     </div>


### PR DESCRIPTION
Link added to notify users how their personal will be used before they actually send it. Also links to submission stages for easier linking from RT replies.

Additionally, removed reference to experiments as we don't accept those (ENA does).