### PR TITLE
EVA-924 Allow multiple ids in search

### DIFF
--- a/src/js/eva-manager-config.js
+++ b/src/js/eva-manager-config.js
@@ -101,7 +101,12 @@ var EvaManager = {
             query = '/' + config.query;
         }
 
-        var url = config.host + '/' + config.version + '/' + config.category + query + '/' + config.resource;
+        // the resource is just added if is not null to avoid composing URLS  like "query/?param=..."
+        if (typeof config.resource !== 'undefined' && config.resource != null) {
+            query = query + '/' + config.resource;
+        }
+
+        var url = config.host + '/' + config.version + '/' + config.category + query;
         url = Utils.addQueryParamtersToUrl(config.params, url);
         return url;
     }

--- a/src/js/variant-widget/eva-variant-widget-panel.js
+++ b/src/js/variant-widget/eva-variant-widget-panel.js
@@ -422,6 +422,7 @@ EvaVariantWidgetPanel.prototype = {
                         e.values.snp = e.values.snp.replace(/\s+/g, ",");
                         e.values.snp = e.values.snp.replace(/,+/g, ",");
                         e.values.id = e.values.snp;
+                        this.panel.getForm().findField('snp').setValue(e.values.id);
                     }
 
                     //CONSEQUENCE TYPES CHECK

--- a/src/js/variant-widget/eva-variant-widget-panel.js
+++ b/src/js/variant-widget/eva-variant-widget-panel.js
@@ -418,7 +418,7 @@ EvaVariantWidgetPanel.prototype = {
                         e.values.gene = e.values.gene.toUpperCase();
                     }
 
-                    if (typeof e.values.snp !== 'undefined') {//
+                    if (typeof e.values.snp !== 'undefined') {
                         e.values.snp = e.values.snp.replace(/\s+/g, ",");
                         e.values.snp = e.values.snp.replace(/,+/g, ",");
                         e.values.id = e.values.snp;
@@ -445,7 +445,7 @@ EvaVariantWidgetPanel.prototype = {
                         query = e.values.gene;
                     }
 
-//                    //<!--------Query by ID ----->
+                    //<!--------Query by ID ----->
                     if (e.values.id) {
                         resource = null;
                         category = 'variants';

--- a/src/js/variant-widget/eva-variant-widget-panel.js
+++ b/src/js/variant-widget/eva-variant-widget-panel.js
@@ -419,6 +419,8 @@ EvaVariantWidgetPanel.prototype = {
                     }
 
                     if (typeof e.values.snp !== 'undefined') {//
+                        e.values.snp = e.values.snp.replace(/\s+/g, ",");
+                        e.values.snp = e.values.snp.replace(/,+/g, ",");
                         e.values.id = e.values.snp;
                     }
 
@@ -444,7 +446,7 @@ EvaVariantWidgetPanel.prototype = {
 
 //                    //<!--------Query by ID ----->
                     if (e.values.id) {
-                        resource = 'info';
+                        resource = null;
                         category = 'variants';
                         query = e.values.id;
                     }

--- a/tests/acceptance/variant_browser.js
+++ b/tests/acceptance/variant_browser.js
@@ -39,6 +39,12 @@ test.describe('Variant Browser ('+config.browser()+')', function() {
         });
     });
 
+    test.describe('search by multiple Variant IDs', function() {
+        test.it('Search term "rs555,rs666,rs777" match with column Variant ID values', function() {
+            variantSearchByMutlipleIds(driver);
+        });
+    });
+
     test.describe('search by Species and Chromosomal Location', function() {
         test.it('Search by species  "Goat / CHIR_1.0" and location "2:4000000-4100000"  where column "Chr"  should match with "2" and Position should be between "4000000-4100000"', function() {
             variantSearchBySpeciesandChrLocation(driver);
@@ -149,6 +155,28 @@ function variantSearchById(driver){
     });
     return driver;
 }
+
+function variantSearchByMutlipleIds(driver){
+    driver.findElement(By.id("selectFilter-trigger-picker")).click();
+    driver.findElement(By.xpath("//li[text()='Variant ID']")).click();
+    driver.findElement(By.name("snp")).clear();
+    driver.findElement(By.name("snp")).sendKeys("rs555,rs666,rs777");
+    driver.findElement(By.id("vb-submit-button")).click();
+    config.sleep(driver);
+    driver.wait(until.elementLocated(By.xpath("//div[@id='variant-browser-grid-body']//table[1]//td[3]/div[text()]")), config.wait()).then(function(text) {
+        driver.findElement(By.xpath("//div[@id='variant-browser-grid-body']//table[1]//td[3]/div[text()]")).getText().then(function(text){
+            chai.assert.equal(text, 'rs666');
+        });
+        driver.findElement(By.xpath("//div[@id='variant-browser-grid-body']//table[2]//td[3]/div[text()]")).getText().then(function(text){
+            chai.assert.equal(text, 'rs777');
+        });
+        driver.findElement(By.xpath("//div[@id='variant-browser-grid-body']//table[3]//td[3]/div[text()]")).getText().then(function(text){
+            chai.assert.equal(text, 'rs555');
+        });
+    });
+    return driver;
+}
+
 function variantSearchBySpeciesandChrLocation(driver){
     driver.findElement(By.id("selectFilter-trigger-picker")).click();
     driver.findElement(By.xpath("//li[text()='Chromosomal Location']")).click();


### PR DESCRIPTION
- Changed WS endpoint used to filter by variant id
- Replace whitespaces (including tabs or line jumps) by "," in the variant id search box