### PR TITLE
EVA-1263 Study browser / view pointing to DGVa API

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -418,7 +418,7 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-contrib-rename');
     grunt.loadNpmTasks('grunt-html-build');
     grunt.loadNpmTasks('grunt-hub');
-//     grunt.loadNpmTasks('grunt-mocha-test');
+    grunt.loadNpmTasks('grunt-mocha-test');
     grunt.loadNpmTasks('grunt-exec');
     grunt.loadNpmTasks('grunt-contrib-cssmin');
     grunt.loadNpmTasks('grunt-minify-html');
@@ -426,7 +426,7 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-bower-task');
     grunt.loadNpmTasks('grunt-config');
     grunt.loadNpmTasks('grunt-replace');
-//     grunt.loadNpmTasks('grunt-mocha-phantomjs');
+    grunt.loadNpmTasks('grunt-mocha-phantomjs');
 
     grunt.loadNpmTasks('grunt-serve');
 
@@ -437,10 +437,10 @@ module.exports = function (grunt) {
     grunt.registerTask('replace-html', ['replace:html']);
 
     //selenium with mocha
-//     grunt.registerTask('acceptanceTest', ['mochaTest:acceptanceTest']);
+    grunt.registerTask('acceptanceTest', ['mochaTest:acceptanceTest']);
 
     // unit tests wirh mocha_phantomjs to run from command line
-//     grunt.registerTask('unitTest', ['mocha_phantomjs:unitTest']);
+    grunt.registerTask('unitTest', ['mocha_phantomjs:unitTest']);
 
     //run test
     grunt.registerTask('runAcceptanceTest', ['exec:firefox']);
@@ -469,8 +469,8 @@ module.exports = function (grunt) {
         'htmlbuild:eva',
         'replace-html',
         'minifyHtml',
-        'imagemin'
-//         'unitTest',
-//         'runAcceptanceTest'
+        'imagemin',
+        'unitTest',
+        'runAcceptanceTest'
     ]);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -52,38 +52,42 @@ module.exports = function (grunt) {
             dev: {
                 options: {
                     variables: {
-                        'EVA_HOST': 'wwwint.ebi.ac.uk/eva/webservices/rest',
-                        'EVA_VERSION': 'v1',
                         'CELLBASE_HOST': 'wwwint.ebi.ac.uk/cellbase/webservices/rest',
                         'CELLBASE_VERSION': 'v3',
                         'DBSNP_HOST': 'wwwint.ebi.ac.uk/dbsnp/webservices/rest',
-                        'DBSNP_VERSION': 'v1'
-
+                        'DBSNP_VERSION': 'v1',
+                        'DGVA_HOST': 'wwwint.ebi.ac.uk/dgva/webservices/rest',
+                        'DGVA_VERSION': 'v1',
+                        'EVA_HOST': 'wwwint.ebi.ac.uk/eva/webservices/rest',
+                        'EVA_VERSION': 'v1'
                     }
                 }
             },
             staging: {
                 options: {
                     variables: {
-                        'EVA_HOST': 'wwwdev.ebi.ac.uk/eva/webservices/rest',
-                        'EVA_VERSION': 'v1',
                         'CELLBASE_HOST': 'wwwdev.ebi.ac.uk/cellbase/webservices/rest',
                         'CELLBASE_VERSION': 'v3',
                         'DBSNP_HOST': 'wwwdev.ebi.ac.uk/dbsnp/webservices/rest',
-                        'DBSNP_VERSION': 'v1'
-
+                        'DBSNP_VERSION': 'v1',
+                        'DGVA_HOST': 'wwwdev.ebi.ac.uk/dgva/webservices/rest',
+                        'DGVA_VERSION': 'v1',
+                        'EVA_HOST': 'wwwdev.ebi.ac.uk/eva/webservices/rest',
+                        'EVA_VERSION': 'v1'
                     }
                 }
             },
             prod: {
                 options: {
                     variables: {
-                        'EVA_HOST': 'www.ebi.ac.uk/eva/webservices/rest',
-                        'EVA_VERSION': 'v1',
                         'CELLBASE_HOST': 'www.ebi.ac.uk/cellbase/webservices/rest',
                         'CELLBASE_VERSION': 'v3',
                         'DBSNP_HOST': 'www.ebi.ac.uk/dbsnp/webservices/rest',
-                        'DBSNP_VERSION': 'v1'
+                        'DBSNP_VERSION': 'v1',
+                        'DGVA_HOST': 'www.ebi.ac.uk/dgva/webservices/rest',
+                        'DGVA_VERSION': 'v1',
+                        'EVA_HOST': 'www.ebi.ac.uk/eva/webservices/rest',
+                        'EVA_VERSION': 'v1'
                     }
                 }
             }
@@ -92,14 +96,6 @@ module.exports = function (grunt) {
             eva_manager: {
                 options: {
                     patterns: [
-                        {
-                            match: 'EVA_HOST',
-                            replacement: '<%= grunt.config.get("EVA_HOST") %>'
-                        },
-                        {
-                            match: 'EVA_VERSION',
-                            replacement: '<%= grunt.config.get("EVA_VERSION") %>'
-                        },
                         {
                             match: 'CELLBASE_HOST',
                             replacement: '<%= grunt.config.get("CELLBASE_HOST") %>'
@@ -115,6 +111,22 @@ module.exports = function (grunt) {
                         {
                             match: 'DBSNP_VERSION',
                             replacement: '<%= grunt.config.get("DBSNP_VERSION") %>'
+                        },
+                        {
+                            match: 'DGVA_HOST',
+                            replacement: '<%= grunt.config.get("DGVA_HOST") %>'
+                        },
+                        {
+                            match: 'DGVA_VERSION',
+                            replacement: '<%= grunt.config.get("DGVA_VERSION") %>'
+                        },
+                        {
+                            match: 'EVA_HOST',
+                            replacement: '<%= grunt.config.get("EVA_HOST") %>'
+                        },
+                        {
+                            match: 'EVA_VERSION',
+                            replacement: '<%= grunt.config.get("EVA_VERSION") %>'
                         }
                     ]
                 },
@@ -457,7 +469,7 @@ module.exports = function (grunt) {
         'htmlbuild:eva',
         'replace-html',
         'minifyHtml',
-        'imagemin',
+        'imagemin'
         'unitTest',
         'runAcceptanceTest'
     ]);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -418,7 +418,7 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-contrib-rename');
     grunt.loadNpmTasks('grunt-html-build');
     grunt.loadNpmTasks('grunt-hub');
-    grunt.loadNpmTasks('grunt-mocha-test');
+//     grunt.loadNpmTasks('grunt-mocha-test');
     grunt.loadNpmTasks('grunt-exec');
     grunt.loadNpmTasks('grunt-contrib-cssmin');
     grunt.loadNpmTasks('grunt-minify-html');
@@ -426,7 +426,7 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-bower-task');
     grunt.loadNpmTasks('grunt-config');
     grunt.loadNpmTasks('grunt-replace');
-    grunt.loadNpmTasks('grunt-mocha-phantomjs');
+//     grunt.loadNpmTasks('grunt-mocha-phantomjs');
 
     grunt.loadNpmTasks('grunt-serve');
 
@@ -437,10 +437,10 @@ module.exports = function (grunt) {
     grunt.registerTask('replace-html', ['replace:html']);
 
     //selenium with mocha
-    grunt.registerTask('acceptanceTest', ['mochaTest:acceptanceTest']);
+//     grunt.registerTask('acceptanceTest', ['mochaTest:acceptanceTest']);
 
     // unit tests wirh mocha_phantomjs to run from command line
-    grunt.registerTask('unitTest', ['mocha_phantomjs:unitTest']);
+//     grunt.registerTask('unitTest', ['mocha_phantomjs:unitTest']);
 
     //run test
     grunt.registerTask('runAcceptanceTest', ['exec:firefox']);
@@ -470,7 +470,7 @@ module.exports = function (grunt) {
         'replace-html',
         'minifyHtml',
         'imagemin'
-        'unitTest',
-        'runAcceptanceTest'
+//         'unitTest',
+//         'runAcceptanceTest'
     ]);
 };

--- a/src/js/eva-manager-config.js
+++ b/src/js/eva-manager-config.js
@@ -19,12 +19,16 @@
  *
  */
 
-EVA_HOST = window.location.protocol + "//@@EVA_HOST";
 CELLBASE_HOST = window.location.protocol + "//@@CELLBASE_HOST";
 DBSNP_HOST = window.location.protocol + "//@@DBSNP_HOST";
-EVA_VERSION = '@@EVA_VERSION';
+DGVA_HOST = window.location.protocol + "//@@DGVA_HOST";
+EVA_HOST = window.location.protocol + "//@@EVA_HOST";
+
 CELLBASE_VERSION = '@@CELLBASE_VERSION';
 DBSNP_VERSION = '@@DBSNP_VERSION';
+DGVA_VERSION = '@@DGVA_VERSION';
+EVA_VERSION = '@@EVA_VERSION';
+
 
 var EvaManager = {
     host: EVA_HOST,
@@ -107,6 +111,88 @@ var EvaManager = {
         }
 
         var url = config.host + '/' + config.version + '/' + config.category + query;
+        url = Utils.addQueryParamtersToUrl(config.params, url);
+        return url;
+    }
+};
+
+
+var DgvaManager = {
+    host: DGVA_HOST,
+    version: DGVA_VERSION,
+    get: function (args) {
+        var success = args.success;
+        var error = args.error;
+        var async = (_.isUndefined(args.async) || _.isNull(args.async) ) ? true : args.async;
+        var urlConfig = _.omit(args, ['success', 'error', 'async']);
+
+        var url = DgvaManager.url(urlConfig);
+        if (typeof url === 'undefined') {
+            return;
+        }
+        console.log(url);
+
+        var d;
+        $.ajax({
+            type: 'GET',
+            url: url,
+            dataType: 'json',//still firefox 20 does not auto serialize JSON, You can force it to always do the parsing by adding dataType: 'json' to your call.
+            async: async,
+            success: function (data, textStatus, jqXHR) {
+                if ($.isPlainObject(data) || $.isArray(data)) {
+                    data.query = args.query;
+                    if (_.isFunction(success)) success(data);
+                    d = data;
+                } else {
+                    console.log('Eva returned a non json object or list, please check the url.');
+                    console.log(url);
+                    console.log(data)
+                }
+            },
+            error: function (jqXHR, textStatus, errorThrown) {
+                console.log("DgvaManager: Ajax call returned : " + errorThrown + '\t' + textStatus + '\t' + jqXHR.statusText + " END");
+                if (_.isFunction(error)) error(jqXHR, textStatus, errorThrown);
+            }
+        });
+        return d;
+    },
+    url: function (args) {
+        if (!$.isPlainObject(args)) args = {};
+        if (!$.isPlainObject(args.params)) args.params = {};
+
+        var version = this.version;
+        if (typeof args.version !== 'undefined' && args.version != null) {
+            version = args.version
+        }
+
+        var host = this.host;
+        if (typeof args.host !== 'undefined' && args.host != null) {
+            host = args.host;
+        }
+
+        delete args.host;
+        delete args.version;
+
+        var config = {
+            host: host,
+            version: version
+        };
+
+        var params = {
+        };
+
+        _.extend(config, args);
+        _.extend(config.params, params);
+
+        var query = '';
+        if (typeof config.query !== 'undefined' && config.query != null) {
+            if ($.isArray(config.query)) {
+                config.query = config.query.toString();
+            }
+            query = '/' + config.query;
+        }
+
+        var url = config.host + '/' + config.version + '/' + config.category + query + '/' + config.resource;
         url = Utils.addQueryParamtersToUrl(config.params, url);
         return url;
     }

--- a/src/js/study-browser/eva-study-browser-widget-panel.js
+++ b/src/js/study-browser/eva-study-browser-widget-panel.js
@@ -214,10 +214,11 @@ EvaStudyBrowserWidgetPanel.prototype = {
                     console.log(e)
                     var params = e.values;
                     if (params.browserType == 'sv') {
-                        _.extend(params, {structural: true})
+                        _this._loadStructuralStudies(params);
+                    } else {
+                        _this._loadStudies(params);
                     }
 
-                    _this._loadStudies(params);
                     if (params.search) {
                         _this._textSearch(params.search);
                     }
@@ -244,15 +245,14 @@ EvaStudyBrowserWidgetPanel.prototype = {
 
         this.browserTypeFilter.on('browserType:change', function (e) {
             var btValue = _this.formPanelStudyFilter.panel.getForm().findField('browserTypeRadio').getValue();
-            var params;
+            var values = formPanel.getValues();
+
             if (btValue.browserType == 'sv') {
-                params = {structural: true};
+                _this._loadStructuralStudies(values);
+            } else {
+                _this._loadStudies(values);
             }
 
-            _this._loadFilterPanelvalues(params)
-            var values = formPanel.getValues();
-            _.extend(values, params)
-            _this._loadStudies(values);
             if(_this.pushURL) {
                 _this._updateURL(values);
             }
@@ -425,6 +425,7 @@ EvaStudyBrowserWidgetPanel.prototype = {
             }
         });
     },
+
     _loadStudies: function (params) {
         var _this = this;
         params.species = params.genome;
@@ -447,6 +448,30 @@ EvaStudyBrowserWidgetPanel.prototype = {
             }
         });
     },
+
+    _loadStructuralStudies: function (params) {
+        var _this = this;
+        params.species = params.genome;
+        params = _.omit(params, ['genome']);
+        _this._updateColumns(params)
+        DgvaManager.get({
+            category: 'meta/studies',
+            resource: 'all',
+            params: params,
+            async: false,
+            success: function (response) {
+                var studies = [];
+                try {
+                    studies = response.response[0].result;
+                } catch (e) {
+                    console.log(e);
+                }
+                _this.studyBrowserWidget.load(studies)
+                _this.resize(true);
+            }
+        });
+    },
+
     _updateColumns: function (params) {
         var _this = this;
         var columns = _this.studyColumns;

--- a/tests/acceptance/study_view.js
+++ b/tests/acceptance/study_view.js
@@ -156,7 +156,7 @@ function dgvaCheckSummaryTable(driver){
             assert(text).matches(regExp);
         });
         driver.findElement(By.id("taxonomy-id-span")).getText().then(function(text){
-            var values = text.split(",");
+            var values = text.split(", ");
             for (var i = 0; i < values.length; i++) {
                 assert(values[i]).matches(numExp);
             }
@@ -172,9 +172,6 @@ function dgvaCheckSummaryTable(driver){
         });
         driver.findElement(By.id("assembly-span")).getText().then(function(text){
             assert(text).matches(regExp);
-        });
-        driver.findElement(By.id("variants-span")).getText().then(function(text){
-            assert(text).matches(numExp);
         });
         driver.findElement(By.id("description-span")).getText().then(function(text){
             assert(text).matches(regExp);


### PR DESCRIPTION
Requires https://github.com/EBIvariation/eva-ws/pull/95 to be merged and deployed first.

Using DGVa REST API in study browser and view, instead of EVA's. A new "manager" created that basically replicates the behavior of the EVA one, and displays unified for both archives.