### PR TITLE
EVA-1366 Twitter handle corrected

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -288,7 +288,7 @@
                     <h2>Feedback</h2>
                     <div>
                         <p>If you have any questions related to the European Variation Archive resource, please <a href="mailto:eva-helpdesk@ebi.ac.uk">contact us</a>.</p>
-                        <p>Follow us on Twitter using <a href="https://twitter.com/EBIvariation" target="_blank">@EBIvariation</a></p>
+                        <p>Follow us on Twitter using <a href="https://twitter.com/evarchive" target="_blank">@evarchive</a></p>
                     </div>
                     <div id="feedback-form">
                         <div class="row">

--- a/src/js/eva.js
+++ b/src/js/eva.js
@@ -392,7 +392,7 @@ Eva.prototype = {
 
         var twitterWidgetEl = document.getElementById('twitter-widget');
         twitterWidgetEl.innerHTML = "";
-        twitterWidgetEl.innerHTML = '<a  class="twitter-timeline"  href="https://twitter.com/EBIvariation"  height="100" data-widget-id="437894469380100096" data-chrome="noheader nofooter noborders transparent">Tweets by @EBIvariation</a>';
+        twitterWidgetEl.innerHTML = '<a  class="twitter-timeline"  href="https://twitter.com/evarchive"  height="100" data-widget-id="437894469380100096" data-chrome="noheader nofooter noborders transparent">Tweets by @evarchive</a>';
         $.getScript('//platform.twitter.com/widgets.js', function () {
            // twttr.widgets.load();
         });


### PR DESCRIPTION
The EVA Twitter handle is 'evarchive'. Maybe 'EBIvariation' was used at the beginning and the redirection was deprecated?