### PR TITLE
EVA-1268 Modify dbsnp import progress report with number of species to show and new column for ss count

### DIFF
--- a/src/js/dbSNP-import/dbSNP-import-progress.js
+++ b/src/js/dbSNP-import/dbSNP-import-progress.js
@@ -131,6 +131,9 @@ EvadbSNPImportProgress.prototype = {
             // truncate the proportion to 4 decimals, to be showed as a percentage with 2 decimals
             proportion = Math.floor((importedIds / totalIds) * 10000) / 10000;
             progress = importedIds.toLocaleString() + ' / ' + totalIds.toLocaleString();
+        } else if(totalIds) {
+            proportion = 0;
+            progress = '0 / ' + totalIds.toLocaleString();
         } else {
             proportion = 0;
             progress = '0 / 0';

--- a/src/js/dbSNP-import/dbSNP-import-progress.js
+++ b/src/js/dbSNP-import/dbSNP-import-progress.js
@@ -28,7 +28,7 @@ EvadbSNPImportProgress.prototype = {
     render: function () {
         var _this = this;
         _this._draw( _this._createContent());
-        $("#dbSNP-import-table").tablesorter({ sortList: [[5,1], [7,1], [0,0]] });
+        $("#dbSNP-import-table").tablesorter({ sortList: [[5,1], [6,1], [0,0]] });
         //sending tracking data to Google Analytics
         ga('send', 'event', { eventCategory: 'Views', eventAction: 'EvadbSNPImportProgress', eventLabel: 'EvadbSNPImportProgress'});
     },
@@ -85,8 +85,8 @@ EvadbSNPImportProgress.prototype = {
                 '</tr>' +
                 '<tr>' +
                     '<th><div title="RS IDs and associated SS IDs available in the last dbSNP build for a species">Current RS IDs <i class="icon icon-generic" data-icon="i"></div></th>' +
-                    '<th><div title="RS IDs merged into others">Synonymous RS IDs <i class="icon icon-generic" data-icon="i"></div></th>' +
                     '<th><div title="SS IDs available in the last dbSNP build for a species">Current SS IDs <i class="icon icon-generic" data-icon="i"></div></th>' +
+                    '<th><div title="RS IDs merged into others">Synonymous RS IDs <i class="icon icon-generic" data-icon="i"></div></th>' +
                 '</tr>' +
                 '</thead><tbody>';
 
@@ -104,20 +104,18 @@ EvadbSNPImportProgress.prototype = {
             }
 
             var importedRs = _this._getImportStatus(this[key].importedRs, this[key].totalRsDbsnp);
-
-            var importedSynonymousRs = _this._getImportStatus(this[key].importedSynonymousRs, this[key].totalSynonymousRsDbsnp);
-            
             var importedSs = _this._getImportStatus(this[key].importedSs, this[key].totalSsDbsnp);
+            var importedSynonymousRs = _this._getImportStatus(this[key].importedSynonymousRs, this[key].totalSynonymousRsDbsnp);
 
             table += '<tr>' +
-                '<td style="text-align:left;"><span class="dbSNP-common-name">'+this[key].commonName+'</span></td>' +
-                '<td style="text-align:left;"><span class="dbSNP-scientific-name">'+this[key].scientificName+'</span></td>' +
+                '<td><span class="dbSNP-common-name">'+this[key].commonName+'</span></td>' +
+                '<td><span class="dbSNP-scientific-name">'+this[key].scientificName+'</span></td>' +
                 '<td><span class="dbSNP-tax-id">'+taxonomy_link+'</span></td>' +
                 '<td><span class="dbSNP-assembly-accession">'+genbankAssemblyAccession+'</span></td>' +
                 '<td><span class="dbSNP-build">'+this[key].lastDbsnpBuild+'</span></td>' +
                 '<td><span class="dbSNP-imported-rs">'+importedRs+'</span></td>' + 
-                '<td><span class="dbSNP-imported-synonymous-rs">'+importedSynonymousRs+'</span></td>' +
                 '<td><span class="dbSNP-imported-ss">'+importedSs+'</span></td>' +
+                '<td><span class="dbSNP-imported-synonymous-rs">'+importedSynonymousRs+'</span></td>' +
                 '</tr>';
         }, data);
         table += '</tbody></table></div></div>';

--- a/src/js/dbSNP-import/dbSNP-import-progress.js
+++ b/src/js/dbSNP-import/dbSNP-import-progress.js
@@ -28,7 +28,7 @@ EvadbSNPImportProgress.prototype = {
     render: function () {
         var _this = this;
         _this._draw( _this._createContent());
-        $("#dbSNP-import-table").tablesorter({ sortList: [[5,1], [0,0]] });
+        $("#dbSNP-import-table").tablesorter({ sortList: [[5,1], [7,1], [0,0]] });
         //sending tracking data to Google Analytics
         ga('send', 'event', { eventCategory: 'Views', eventAction: 'EvadbSNPImportProgress', eventLabel: 'EvadbSNPImportProgress'});
     },
@@ -86,6 +86,7 @@ EvadbSNPImportProgress.prototype = {
                 '<tr>' +
                     '<th><div title="RS IDs and associated SS IDs available in the last dbSNP build for a species">Current RS IDs <i class="icon icon-generic" data-icon="i"></div></th>' +
                     '<th><div title="RS IDs merged into others">Synonymous RS IDs <i class="icon icon-generic" data-icon="i"></div></th>' +
+                    '<th><div title="SS IDs available in the last dbSNP build for a species">Current SS IDs <i class="icon icon-generic" data-icon="i"></div></th>' +
                 '</tr>' +
                 '</thead><tbody>';
 
@@ -102,18 +103,21 @@ EvadbSNPImportProgress.prototype = {
                 taxonomy_link = '<a target="_blank" href="https://www.ebi.ac.uk/ena/data/view/Taxon:'+this[key].taxId+'">'+this[key].taxId+'</a>';
             }
 
-            var importedIds = _this._getImportStatus(this[key].importedIds, this[key].totalIdsDbsnp);
+            var importedRs = _this._getImportStatus(this[key].importedRs, this[key].totalRsDbsnp);
 
-            var importedSynonymousIds = _this._getImportStatus(this[key].importedSynonymousIds, this[key].totalSynonymousIdsDbsnp);            
+            var importedSynonymousRs = _this._getImportStatus(this[key].importedSynonymousRs, this[key].totalSynonymousRsDbsnp);
+            
+            var importedSs = _this._getImportStatus(this[key].importedSs, this[key].totalSsDbsnp);
 
             table += '<tr>' +
-                '<td><span class="dbSNP-common-name">'+this[key].commonName+'</span></td>' +
-                '<td><span class="dbSNP-scientific-name">'+this[key].scientificName+'</span></td>' +
+                '<td style="text-align:left;"><span class="dbSNP-common-name">'+this[key].commonName+'</span></td>' +
+                '<td style="text-align:left;"><span class="dbSNP-scientific-name">'+this[key].scientificName+'</span></td>' +
                 '<td><span class="dbSNP-tax-id">'+taxonomy_link+'</span></td>' +
                 '<td><span class="dbSNP-assembly-accession">'+genbankAssemblyAccession+'</span></td>' +
                 '<td><span class="dbSNP-build">'+this[key].lastDbsnpBuild+'</span></td>' +
-                '<td><span class="dbSNP-imported-ids">'+importedIds+'</span></td>' + 
-                '<td><span class="dbSNP-imported-synonymous-ids">'+importedSynonymousIds+'</span></td>' +
+                '<td><span class="dbSNP-imported-rs">'+importedRs+'</span></td>' + 
+                '<td><span class="dbSNP-imported-synonymous-rs">'+importedSynonymousRs+'</span></td>' +
+                '<td><span class="dbSNP-imported-ss">'+importedSs+'</span></td>' +
                 '</tr>';
         }, data);
         table += '</tbody></table></div></div>';

--- a/src/js/dbSNP-import/dbSNP-import-progress.js
+++ b/src/js/dbSNP-import/dbSNP-import-progress.js
@@ -49,7 +49,7 @@ EvadbSNPImportProgress.prototype = {
             version: DBSNP_VERSION,
             category: 'import-status',
             resource: '',
-            params:{size:80},
+            params:{size:190},
             async: false,
             success: function (response) {
                 try {

--- a/src/js/dbSNP-import/dbSNP-import-progress.js
+++ b/src/js/dbSNP-import/dbSNP-import-progress.js
@@ -84,7 +84,7 @@ EvadbSNPImportProgress.prototype = {
                     '<th colspan="3" style="background-image:none;">Searchable by</th>' +
                 '</tr>' +
                 '<tr>' +
-                    '<th><div title="RS IDs and associated SS IDs available in the last dbSNP build for a species">Current RS IDs <i class="icon icon-generic" data-icon="i"></div></th>' +
+                    '<th><div title="RS IDs available in the last dbSNP build for a species">Current RS IDs <i class="icon icon-generic" data-icon="i"></div></th>' +
                     '<th><div title="SS IDs available in the last dbSNP build for a species">Current SS IDs <i class="icon icon-generic" data-icon="i"></div></th>' +
                     '<th><div title="RS IDs merged into others">Synonymous RS IDs <i class="icon icon-generic" data-icon="i"></div></th>' +
                 '</tr>' +

--- a/tests/acceptance/dbSNP_import.js
+++ b/tests/acceptance/dbSNP_import.js
@@ -39,7 +39,7 @@ test.describe('dbSNP Import Progress ('+config.browser()+')', function() {
                 driver.findElements(By.className("dbSNP-scientific-name")).then(function(rows){
                     for (var i = 0; i < rows.length; i++){
                         rows[i].getText().then(function(text){
-                            assert(text).matches(/\w+.$/);
+                            assert(text).matches(/\w+.*$/);
                         });
                     }
                 });
@@ -51,7 +51,7 @@ test.describe('dbSNP Import Progress ('+config.browser()+')', function() {
                 driver.findElements(By.className("dbSNP-common-name")).then(function(rows){
                     for (var i = 0; i < rows.length; i++){
                         rows[i].getText().then(function(text){
-                            assert(text).matches(/\w+$/);
+                            assert(text).matches(/\w+.*$/);
                         });
                     }
                 });
@@ -96,7 +96,7 @@ test.describe('dbSNP Import Progress ('+config.browser()+')', function() {
 
         test.it('Check "Current RS IDs" column should not be empty', function() {
             driver.wait(until.elementLocated(By.id("dbSNP-import-table")), config.wait()).then(function(text) {
-                driver.findElements(By.className("dbSNP-imported-ids")).then(function(rows){
+                driver.findElements(By.className("dbSNP-imported-rs")).then(function(rows){
                     for (var i = 0; i < rows.length; i++){
                         rows[i].getAttribute("innerHTML").then(function(text){
                             chai.assert.notEqual(text, null);
@@ -108,7 +108,19 @@ test.describe('dbSNP Import Progress ('+config.browser()+')', function() {
 
         test.it('Check "Synonymous RS IDs" column should not be empty', function() {
             driver.wait(until.elementLocated(By.id("dbSNP-import-table")), config.wait()).then(function(text) {
-                driver.findElements(By.className("dbSNP-imported-synonymous-ids")).then(function(rows){
+                driver.findElements(By.className("dbSNP-imported-synonymous-rs")).then(function(rows){
+                    for (var i = 0; i < rows.length; i++){
+                        rows[i].getAttribute("innerHTML").then(function(text){
+                            chai.assert.notEqual(text, null);
+                        });
+                    }
+                });
+            });
+        });
+
+        test.it('Check "Current SS IDs" column should not be empty', function() {
+            driver.wait(until.elementLocated(By.id("dbSNP-import-table")), config.wait()).then(function(text) {
+                driver.findElements(By.className("dbSNP-imported-ss")).then(function(rows){
                     for (var i = 0; i < rows.length; i++){
                         rows[i].getAttribute("innerHTML").then(function(text){
                             chai.assert.notEqual(text, null);

--- a/tests/acceptance/dbSNP_import.js
+++ b/tests/acceptance/dbSNP_import.js
@@ -106,9 +106,9 @@ test.describe('dbSNP Import Progress ('+config.browser()+')', function() {
             });
         });
 
-        test.it('Check "Synonymous RS IDs" column should not be empty', function() {
+        test.it('Check "Current SS IDs" column should not be empty', function() {
             driver.wait(until.elementLocated(By.id("dbSNP-import-table")), config.wait()).then(function(text) {
-                driver.findElements(By.className("dbSNP-imported-synonymous-rs")).then(function(rows){
+                driver.findElements(By.className("dbSNP-imported-ss")).then(function(rows){
                     for (var i = 0; i < rows.length; i++){
                         rows[i].getAttribute("innerHTML").then(function(text){
                             chai.assert.notEqual(text, null);
@@ -118,9 +118,9 @@ test.describe('dbSNP Import Progress ('+config.browser()+')', function() {
             });
         });
 
-        test.it('Check "Current SS IDs" column should not be empty', function() {
+        test.it('Check "Synonymous RS IDs" column should not be empty', function() {
             driver.wait(until.elementLocated(By.id("dbSNP-import-table")), config.wait()).then(function(text) {
-                driver.findElements(By.className("dbSNP-imported-ss")).then(function(rows){
+                driver.findElements(By.className("dbSNP-imported-synonymous-rs")).then(function(rows){
                     for (var i = 0; i < rows.length; i++){
                         rows[i].getAttribute("innerHTML").then(function(text){
                             chai.assert.notEqual(text, null);


### PR DESCRIPTION
- The number is species shown in the dbsnp import progress report was changed from 80 to 190.
- The column `Current SS IDs` was added to the report
- The order of the report is: Current RS IDs (DESC), Current SS IDs (DESC), Common name (ASC)
