### PR TITLE
EVA-1388 - Fixed taxonomyId for Cottonwood and variant view fixes

### DIFF
--- a/src/js/eva-config.js
+++ b/src/js/eva-config.js
@@ -51,7 +51,7 @@ function getSpeciesList() {
                             "assemblyName": "Brapa_1.0", "assemblyCode": "Brapa_1.0"},
         {"taxonomyEvaName": "Barrel medic", "taxonomyId": 3880, "taxonomyCode": "mtruncatula", "assemblyAccession" : "GCF_000219495.1",
                             "assemblyName": "MedtrA17_3.5", "assemblyCode": "MedtrA17_3.5"},
-        {"taxonomyEvaName": "Cottonwood", "taxonomyId": 3994, "taxonomyCode": "ptrichocarpa", "assemblyAccession" : "GCF_000002775.1",
+        {"taxonomyEvaName": "Cottonwood", "taxonomyId": 3694, "taxonomyCode": "ptrichocarpa", "assemblyAccession" : "GCF_000002775.1",
                             "assemblyName": "Poptr1_1", "assemblyCode": "Poptr1_1"},
         {"taxonomyEvaName": "Oil palm", "taxonomyId": 51953, "taxonomyCode": "eguineensis", "assemblyAccession" : "GCF_000442705.1",
                             "assemblyName": "EG5", "assemblyCode": "EG5"}

--- a/src/js/variant-widget/eva-variant-population-stats-panel.js
+++ b/src/js/variant-widget/eva-variant-population-stats-panel.js
@@ -129,7 +129,7 @@ EvaVariantPopulationStatsPanel.prototype = {
                     xtype: 'box',
                     id: this.populationStatsPanelID,
                     cls: 'ocb-header-4',
-                    html: '<h4>Population Statistics</h4>' + '<h6><small>' + this.tooltipText + '</small></h6>',
+                    html: this.populationStatsHeading + '<h6><small>' + this.tooltipText + '</small></h6>',
                     margin: this.customMargin ? this.customMargin: '5 0 10 15',
                 },
                 this.studiesContainer

--- a/src/js/views/eva-variant-view.js
+++ b/src/js/views/eva-variant-view.js
@@ -309,14 +309,12 @@ EvaVariantView.prototype = {
                     result.evidence = "Yes";
                     if (attributeToSearchBy.startsWith("rs") || attributeToSearchBy.startsWith("ss")) {
                         result.id = attributeToSearchBy;
-                    }
-                    else {
+                    } else {
                         if (result.associatedSSIDs) {
                             result.associatedSSIDs.forEach(function(ssID){
                                 _this.addAssociatedSSID(ssID + "_" + result.chromosome , {"ID": ssID});});
                             result.id = result.associatedSSIDs.join(",");
-                        }
-                        else {
+                        } else {
                             result.id = [result.chromosome, result.start, result.reference, result.alternate].join(":");
                         }
                     }
@@ -462,8 +460,7 @@ EvaVariantView.prototype = {
         if (this.accessionID) {
             this.accessionCategory = this.accessionID.startsWith("rs") ? "clustered-variants": "submitted-variants";
             this.processQueryWithAccessioningService();
-        }
-        else {
+        } else {
             this.accessionCategory = "submitted-variants";
         }
         // Proceed to EVA warehouse query if query is position-based or the above processing fails

--- a/src/js/views/eva-variant-view.js
+++ b/src/js/views/eva-variant-view.js
@@ -296,8 +296,10 @@ EvaVariantView.prototype = {
             if (this.isValidResponse(results)) {
                 results.forEach(function(result) {
                     _this.addReprToVariantObj(result);
-                    result.associatedRSID = result.ids.filter(function(x) {return x.startsWith("rs");})[0];
-                    result.associatedSSIDs = result.ids.filter(function(x) {return x.startsWith("ss");});
+                    if (result.ids) {
+                        result.associatedRSID = result.ids.filter(function(x) {return x.startsWith("rs");})[0];
+                        result.associatedSSIDs = result.ids.filter(function(x) {return x.startsWith("ss");});
+                    }
                     result.allAlternates = _.uniq([result.alternate].concat(
                                                     _.chain(result.sourceEntries).values().map(function(sourceEntry) {
                                                         return (sourceEntry.secondaryAlternates ?
@@ -307,10 +309,16 @@ EvaVariantView.prototype = {
                     result.evidence = "Yes";
                     if (attributeToSearchBy.startsWith("rs") || attributeToSearchBy.startsWith("ss")) {
                         result.id = attributeToSearchBy;
-                    } else {
-                        // For position based searches, return all possible IDs because EVA service
-                        // cannot precisely tell the ID
-                        result.id = result.ids.filter(function(x) {return x.startsWith("ss");}).join(",");
+                    }
+                    else {
+                        if (result.associatedSSIDs) {
+                            result.associatedSSIDs.forEach(function(ssID){
+                                _this.addAssociatedSSID(ssID + "_" + result.chromosome , {"ID": ssID});});
+                            result.id = result.associatedSSIDs.join(",");
+                        }
+                        else {
+                            result.id = [result.chromosome, result.start, result.reference, result.alternate].join(":");
+                        }
                     }
                 });
                 return results;
@@ -449,11 +457,14 @@ EvaVariantView.prototype = {
         this.studiesList = (_.contains(this.EVASpeciesList, this.species) ? this.getStudiesList(this.species) : []);
         this.currAssembly = this.getCurrentAssembly(this.species, this.speciesList);
         this.assemblyLink = this.getAssemblyLink(this.currAssembly);
-        this.accessionCategory = this.accessionID.startsWith("rs") ? "clustered-variants": "submitted-variants";
         this.associatedSSIDs = {};
 
         if (this.accessionID) {
+            this.accessionCategory = this.accessionID.startsWith("rs") ? "clustered-variants": "submitted-variants";
             this.processQueryWithAccessioningService();
+        }
+        else {
+            this.accessionCategory = "submitted-variants";
         }
         // Proceed to EVA warehouse query if query is position-based or the above processing fails
         if ((this.position || _.isEmpty(this.variant)) && _.contains(this.EVASpeciesList, this.species)) {

--- a/src/js/views/eva-variant-view.js
+++ b/src/js/views/eva-variant-view.js
@@ -295,6 +295,10 @@ EvaVariantView.prototype = {
             var results = webServiceResponse.response[0].result;
             if (this.isValidResponse(results)) {
                 results.forEach(function(result) {
+                    //Work around https://www.ebi.ac.uk/panda/jira/browse/EVA-1398
+                    if (typeof(result.alternate) === "undefined") { result.alternate = ""; }
+                    if (typeof(result.reference) === "undefined") { result.reference = ""; }
+
                     _this.addReprToVariantObj(result);
                     if (result.ids) {
                         result.associatedRSID = result.ids.filter(function(x) {return x.startsWith("rs");})[0];


### PR DESCRIPTION
eva-variant-population-stats-panel.js - Show separate heading for each ref/alt
eva-variant-view.js - explicitly check null values to avoid  variant view rendering interrupted by javascript errors