### PR TITLE
EVA-1465 Bugfix for only one record per database shown in the dbSNP import progress report

### DIFF
--- a/src/js/dbSNP-import/dbSNP-import-progress.js
+++ b/src/js/dbSNP-import/dbSNP-import-progress.js
@@ -52,7 +52,6 @@ EvadbSNPImportProgress.prototype = {
             version: DBSNP_VERSION,
             category: 'import-status',
             resource: '',
-            params:{size:190},
             async: false,
             success: function (response) {
                 try {

--- a/src/js/dbSNP-import/dbSNP-import-progress.js
+++ b/src/js/dbSNP-import/dbSNP-import-progress.js
@@ -24,6 +24,7 @@ function EvadbSNPImportProgress(args) {
     this.rendered = false;
     this.render();
 }
+
 EvadbSNPImportProgress.prototype = {
     render: function () {
         var _this = this;
@@ -32,6 +33,7 @@ EvadbSNPImportProgress.prototype = {
         //sending tracking data to Google Analytics
         ga('send', 'event', { eventCategory: 'Views', eventAction: 'EvadbSNPImportProgress', eventLabel: 'EvadbSNPImportProgress'});
     },
+
     _draw: function (content) {
         var _this = this;
         var el = document.querySelector("#" + this.target);
@@ -41,6 +43,7 @@ EvadbSNPImportProgress.prototype = {
         el.appendChild(elDiv);
         el.applyAuthorStyles = true;
     },
+
     _createContent: function () {
         var _this = this;
         var data;
@@ -95,11 +98,11 @@ EvadbSNPImportProgress.prototype = {
             var taxonomy_link;
 
             if(!this[key].genbankAssemblyAccession.isEmpty()) {
-                genbankAssemblyAccession = '<a target="_blank" href="https://www.ebi.ac.uk/ena/data/view/'+this[key].genbankAssemblyAccession+'">'+this[key].genbankAssemblyAccession+'</a>';
+                genbankAssemblyAccession = '<a target="_blank" href="https://www.ebi.ac.uk/ena/data/view/' + this[key].genbankAssemblyAccession + '">' + this[key].genbankAssemblyAccession + '</a>';
             }
 
-            if(this[key].taxId){
-                taxonomy_link = '<a target="_blank" href="https://www.ebi.ac.uk/ena/data/view/Taxon:'+this[key].taxId+'">'+this[key].taxId+'</a>';
+            if(this[key].taxId) {
+                taxonomy_link = '<a target="_blank" href="https://www.ebi.ac.uk/ena/data/view/Taxon:' + this[key].taxId + '">' + this[key].taxId + '</a>';
             }
 
             var importedRs = _this._getImportStatus(this[key].importedRs, this[key].totalRsDbsnp);
@@ -107,21 +110,21 @@ EvadbSNPImportProgress.prototype = {
             var importedSynonymousRs = _this._getImportStatus(this[key].importedSynonymousRs, this[key].totalSynonymousRsDbsnp);
 
             table += '<tr>' +
-                '<td><span class="dbSNP-common-name">'+this[key].commonName+'</span></td>' +
-                '<td><span class="dbSNP-scientific-name">'+this[key].scientificName+'</span></td>' +
-                '<td><span class="dbSNP-tax-id">'+taxonomy_link+'</span></td>' +
-                '<td><span class="dbSNP-assembly-accession">'+genbankAssemblyAccession+'</span></td>' +
-                '<td><span class="dbSNP-build">'+this[key].lastDbsnpBuild+'</span></td>' +
-                '<td><span class="dbSNP-imported-rs">'+importedRs+'</span></td>' + 
-                '<td><span class="dbSNP-imported-ss">'+importedSs+'</span></td>' +
-                '<td><span class="dbSNP-imported-synonymous-rs">'+importedSynonymousRs+'</span></td>' +
+                '<td><span class="dbSNP-common-name">' + this[key].commonName + '</span></td>' +
+                '<td><span class="dbSNP-scientific-name">' + this[key].scientificName + '</span></td>' +
+                '<td><span class="dbSNP-tax-id">' + taxonomy_link + '</span></td>' +
+                '<td><span class="dbSNP-assembly-accession">' + genbankAssemblyAccession + '</span></td>' +
+                '<td><span class="dbSNP-build">' + this[key].lastDbsnpBuild + '</span></td>' +
+                '<td><span class="dbSNP-imported-rs">' + importedRs + '</span></td>' +
+                '<td><span class="dbSNP-imported-ss">' + importedSs + '</span></td>' +
+                '<td><span class="dbSNP-imported-synonymous-rs">' + importedSynonymousRs + '</span></td>' +
                 '</tr>';
         }, data);
         table += '</tbody></table></div></div>';
         return table;
     },
 
-    _getImportStatus : function (importedIds,totalIds){
+    _getImportStatus : function (importedIds, totalIds) {
         var indicator;
         var percentage;
         var proportion;

--- a/src/js/dbSNP-import/dbSNP-import-progress.js
+++ b/src/js/dbSNP-import/dbSNP-import-progress.js
@@ -53,7 +53,7 @@ EvadbSNPImportProgress.prototype = {
             async: false,
             success: function (response) {
                 try {
-                    data = response._embedded.importStatus;
+                    data = response;
                 } catch (e) {
                     console.log(e);
                 }
@@ -90,12 +90,11 @@ EvadbSNPImportProgress.prototype = {
                 '</tr>' +
                 '</thead><tbody>';
 
-        //data = _.sortBy(data, 'importedIds', 'commonName');
         _.each (_.keys(data), function(key) {
             var genbankAssemblyAccession = '-';
             var taxonomy_link;
 
-            if(!_.isNull(this[key].genbankAssemblyAccession)){
+            if(!this[key].genbankAssemblyAccession.isEmpty()) {
                 genbankAssemblyAccession = '<a target="_blank" href="https://www.ebi.ac.uk/ena/data/view/'+this[key].genbankAssemblyAccession+'">'+this[key].genbankAssemblyAccession+'</a>';
             }
 

--- a/src/js/dbSNP-import/dbSNP-import-progress.js
+++ b/src/js/dbSNP-import/dbSNP-import-progress.js
@@ -97,10 +97,10 @@ EvadbSNPImportProgress.prototype = {
             var genbankAssemblyAccession = '-';
             var taxonomy_link;
 
-            if(!this[key].genbankAssemblyAccession.isEmpty()) {
+            if(this[key].genbankAssemblyAccession) {
                 genbankAssemblyAccession = '<a target="_blank" href="https://www.ebi.ac.uk/ena/data/view/' + this[key].genbankAssemblyAccession + '">' + this[key].genbankAssemblyAccession + '</a>';
             }
-
+            
             if(this[key].taxId) {
                 taxonomy_link = '<a target="_blank" href="https://www.ebi.ac.uk/ena/data/view/Taxon:' + this[key].taxId + '">' + this[key].taxId + '</a>';
             }

--- a/src/js/eva-manager-config.js
+++ b/src/js/eva-manager-config.js
@@ -53,7 +53,7 @@ var EvaManager = {
             async: async,
             success: function (data, textStatus, jqXHR) {
                 if ($.isPlainObject(data) || $.isArray(data)) {
-                    data.query = args.query;
+                    if (args.query) data.query = args.query;
                     if (_.isFunction(success)) success(data);
                     d = data;
                 } else {


### PR DESCRIPTION
Populate the dbSNP import progress report using the new (simplified) response structure from https://github.com/EBIvariation/eva-ws/pull/109, which supports multiple assemblies per database.