### PR TITLE
EVA-1495 — Fix species list in the SNP search dropdown in the homepage

### DIFF
--- a/src/js/eva-config.js
+++ b/src/js/eva-config.js
@@ -65,7 +65,12 @@ function deDuplicatedSpeciesList(speciesList) {
     //In the case of multiple assemblies like Grch37 and Grch37.p13 in the species list, use only the first one since
     //they both have the same assembly name and variants from either assembly reside within the same database
     speciesList = _.sortBy(speciesList, function(listItem) { return listItem.assemblyAccession; });
-    return _.uniq(speciesList, function(listItem, key, unused) { return listItem.assemblyCode; });
+    return _.uniq(speciesList, function(listItem, key, unused) {
+        // Different species can have assembly codes which coincide with each other, e. g. "Pepper Zunla 1 Ref_v1.0"
+        // (taxonomy ID 4072) and L_crocea_1.0 (taxonomy ID 215358) both have the assembly code of "10". Because of
+        // this, we need to have uniq over a tuple of taxonomy ID and assembly code.
+        return [listItem.taxonomyId, listItem.assemblyCode].join();
+    });
 }
 
 function getProjects(){


### PR DESCRIPTION
Fixed by making uniq over two fields, not one.

(The build is failing; however, it was failing before as well.)