### PR TITLE
EVA-1481 - Match assembly with the request fetching assoc. SS in variant view

### DIFF
--- a/src/js/eva-config.js
+++ b/src/js/eva-config.js
@@ -58,13 +58,15 @@ function getSpeciesList() {
     //Use assembly accession to de-duplicate common accessions between the
     //browsable assemblies list and the accessioned assemblies list
     return _.uniq(getEVASpeciesList().concat(getAccessionedSpeciesList()),
-                    function(listItem, key, unused) { return listItem.assemblyAccession; });
+                    function(listItem, key, unused) { return [listItem.taxonomyId, listItem.assemblyAccession].join(); });
 }
 
 function deDuplicatedSpeciesList(speciesList) {
     //In the case of multiple assemblies like Grch37 and Grch37.p13 in the species list, use only the first one since
     //they both have the same assembly name and variants from either assembly reside within the same database
-    speciesList = _.sortBy(speciesList, function(listItem) { return listItem.assemblyAccession; });
+    speciesList = _.sortBy(speciesList, function(listItem) {
+                                            return [listItem.assemblyAccession,
+                                                    listItem.taxonomyEvaName.toLowerCase()].join(); });
     return _.uniq(speciesList, function(listItem, key, unused) {
         // Different species can have assembly codes which coincide with each other, e. g. "Pepper Zunla 1 Ref_v1.0"
         // (taxonomy ID 4072) and L_crocea_1.0 (taxonomy ID 215358) both have the assembly code of "10". Because of

--- a/src/js/variant-widget/filters/eva-species-filter-form-panel.js
+++ b/src/js/variant-widget/filters/eva-species-filter-form-panel.js
@@ -94,10 +94,12 @@ SpeciesFilterFormPanel.prototype = {
 
         var speciesStore = Ext.create('Ext.data.Store', {
             model: 'SpeciesListModel',
-            data: deDuplicatedSpeciesList(_this.speciesList),
+            data: _.uniq(deDuplicatedSpeciesList(_this.speciesList),
+                            function(item) {return item.assemblyAccession;}),
             sorters: [
                 {
                     property: 'taxonomyEvaName',
+                    transform: function(value) {return value.toLowerCase();},
                     direction: 'ASC'
                 }
             ]

--- a/src/js/views/eva-variant-view.js
+++ b/src/js/views/eva-variant-view.js
@@ -229,6 +229,7 @@ EvaVariantView.prototype = {
                 if (variantInfo.species !== selectedSpecies) {
                     return;
                 }
+                variantInfo.assemblyAccession = assemblyFromAccessioningService;
                 variantInfo.projectAccession = response.data.projectAccession;
                 variantInfo.submitterHandle = _this.getProjectAccessionAnchor(variantInfo.projectAccession);
                 variantInfo.chromosome = response.data.contig;
@@ -356,15 +357,17 @@ EvaVariantView.prototype = {
         this.variant.forEach(function(variantObjFromAccService) {
             if (_this.accessionCategory == "clustered-variants") {
                 _this.getAssociatedSSIDsFromAccessioningService(_this.accessionCategory, variantObjFromAccService.id).forEach(function(ssIDInfo) {
-                        _this.addAssociatedSSID("ss" + ssIDInfo.accession + "_" + ssIDInfo.data.contig,
-                        {"ID": "ss" + ssIDInfo.accession,
-                        "Study": _this.getProjectAccessionAnchor(ssIDInfo.data.projectAccession),
-                        "Contig": ssIDInfo.data.contig, "Start": ssIDInfo.data.start,
-                        "End": _this.getVariantEndCoordinate(ssIDInfo.data.start,
-                                                            ssIDInfo.data.referenceAllele, ssIDInfo.data.alternateAllele),
-                        "Reference": ssIDInfo.data.referenceAllele,
-                        "Alternate": [ssIDInfo.data.alternateAllele],
-                        "Created Date": _this.getFormattedDate(ssIDInfo.data.createdDate)});
+                        if (variantObjFromAccService.assemblyAccession == ssIDInfo.data.referenceSequenceAccession) {
+                            _this.addAssociatedSSID("ss" + ssIDInfo.accession + "_" + ssIDInfo.data.contig,
+                            {"ID": "ss" + ssIDInfo.accession,
+                            "Study": _this.getProjectAccessionAnchor(ssIDInfo.data.projectAccession),
+                            "Contig": ssIDInfo.data.contig, "Start": ssIDInfo.data.start,
+                            "End": _this.getVariantEndCoordinate(ssIDInfo.data.start,
+                                                                ssIDInfo.data.referenceAllele, ssIDInfo.data.alternateAllele),
+                            "Reference": ssIDInfo.data.referenceAllele,
+                            "Alternate": [ssIDInfo.data.alternateAllele],
+                            "Created Date": _this.getFormattedDate(ssIDInfo.data.createdDate)});
+                        }
                 });
             }
             // Add attributes from EVA service for the same variant


### PR DESCRIPTION
eva-config.js - Updates to support multiple taxonomies for the same species
eva-species-filter-form-panel.js - Updates to use only one of the taxonomy names in case of "Rice" and "Rice (Japanese)"
eva-variant-view.js - When fetching SS IDs from the /submitted endpoint in the identifier webservice, match the assembly in the response against the assembly for which the search was invoked.