### PR TITLE
EVA-1522 — Roll back tests after staging environment update

### DIFF
--- a/tests/acceptance/variant_browser.js
+++ b/tests/acceptance/variant_browser.js
@@ -489,8 +489,6 @@ function variantFilterByPolyphenSift(driver){
     clickSubmit(driver);
     waitForVariantsToLoad(driver);
     driver.wait(until.elementLocated(By.xpath("//div[@id='variant-browser-grid-body']//table[2]//td[1]/div[text()]")), config.wait()).then(function(text) {
-        // TODO:  The expected number of results in the staging environment is 4 due to an outdated database; when the
-        // TODO:  database is updated, the condition below must be changed back to "i < 11"
         for (let i = 1; i < 5; i++) {
             driver.findElement(By.xpath("//div[@id='variant-browser-grid-body']//table["+i+"]//td[7]/div[text()]")).getText().then(function(text) {
                 var polyphen = parseFloat(text);

--- a/tests/acceptance/variant_view.js
+++ b/tests/acceptance/variant_view.js
@@ -221,10 +221,7 @@ test.describe('Variant View - ss by position', function() {
         config.shutdownDriver(driver);
     });
 
-    // TODO:  GCA_000001405.1 reflects the obsolete assembly version used in the staging environment. Production
-    // TODO:  environment is currently using GCA_000001405.14. When the staging database is updated, the test must be
-    // TODO:  updated
-    var expectedResults = [{"Organism": "Human", "Assembly": "GCA_000001405.1", "Submitter Handle": "", "Contig": "1",
+    var expectedResults = [{"Organism": "Human", "Assembly": "GCA_000001405.14", "Submitter Handle": "", "Contig": "1",
                             "Start": "3000017", "End": "3000017", "Reference": "C", "Alternate": "T", "ID":"ss1289423512",
                             "Type": "", "Allele frequencies / genotypes available?": "Yes",
                             "Alleles match reference assembly?": "", "Passed allele checks?": "",


### PR DESCRIPTION
In the original PR https://github.com/EBIvariation/eva-web/pull/147 I had to temporarily modify the expected results of two tests because the staging environment was outdated and not returning the correct values. In the recent PR https://github.com/EBIvariation/eva-web/pull/148 those tests have failed because the staging environment has (apparently) been updated. We can now roll back these two tests.

In fact, only one of these tests needed the roll back; the error in the other one turned out to be caused by the race condition in the test itself (before refactoring) rather than the staging environment issue.