### PR TITLE
EVA-1624 Change dbSNP import report ordering to only by RS ID % and common name

### DIFF
--- a/src/js/dbSNP-import/dbSNP-import-progress.js
+++ b/src/js/dbSNP-import/dbSNP-import-progress.js
@@ -29,7 +29,7 @@ EvadbSNPImportProgress.prototype = {
     render: function () {
         var _this = this;
         _this._draw( _this._createContent());
-        $("#dbSNP-import-table").tablesorter({ sortList: [[5,1], [6,1], [0,0]] });
+        $("#dbSNP-import-table").tablesorter({ sortList: [[5,1], [0,0]] });
         //sending tracking data to Google Analytics
         ga('send', 'event', { eventCategory: 'Views', eventAction: 'EvadbSNPImportProgress', eventLabel: 'EvadbSNPImportProgress'});
     },


### PR DESCRIPTION
Right now, both the RS ID and SS ID percentage of completion are ordered for sorting, meaning that in practice the alphabetical ordering on names is applied only for 100% on both. Using only the RS ID and the name allows to form clusters for 100%, 99.99%, etc.

Therefore, the dbSNP import progress report is no longer ordered by SS ID %.