### PR TITLE
EVA-1374 - Support haploid genotypes in the Variant Browser

### DIFF
--- a/src/js/variant-widget/eva-variant-genotype-grid-panel.js
+++ b/src/js/variant-widget/eva-variant-genotype-grid-panel.js
@@ -322,40 +322,40 @@ EvaVariantGenotypeGridPanel.prototype = {
     }
 };
 String.prototype.formatAlleles = function () {
-    var allels = this;
-    var temp;
-    var first;
-    var second;
-    var split;
+    var alleles = this;
+    var splitAlleles;
+    var firstAllele;
+    var secondAllele;
+    var splitChar;
     var haploid_genotype = (this.indexOf("/") == -1 && this.indexOf("|") == -1);
 
     if (!haploid_genotype) {
-        if (allels.match(/-1\/-1/)) {
-            allels = './.';
-        }else if(allels.match(/-1\|-1/)){
-            allels = '.|.';
+        if (alleles.match(/-1\/-1/)) {
+            alleles = './.';
+        }else if(alleles.match(/-1\|-1/)){
+            alleles = '.|.';
         }
 
         if (this.indexOf("|") > -1) {
-            temp = allels.split("|");
-            split = '|';
+            splitAlleles = alleles.split("|");
+            splitChar = '|';
         }else if(this.indexOf("/") > -1) {
-            temp = allels.split("/");
-            split = '/';
+            splitAlleles = alleles.split("/");
+            splitChar = '/';
         }
-        if(!_.isEmpty( temp[0]) && !_.isUndefined(temp[0]) && temp[0] > 1){
-            first = '*';
+        if(!_.isEmpty( splitAlleles[0]) && !_.isUndefined(splitAlleles[0]) && splitAlleles[0] > 1){
+            firstAllele = '*';
         }else{
-            first = temp[0];
+            firstAllele = splitAlleles[0];
         }
 
-        if(!_.isEmpty( temp[1]) && !_.isUndefined(temp[1]) && temp[1] > 1){
-            second = '*';
+        if(!_.isEmpty( splitAlleles[1]) && !_.isUndefined(splitAlleles[1]) && splitAlleles[1] > 1){
+            secondAllele = '*';
         }else{
-            second = temp[1];
+            secondAllele = splitAlleles[1];
         }
-        allels = first+split+second;
+        alleles = firstAllele+splitChar+secondAllele;
     }
 
-    return allels;
+    return alleles;
 };

--- a/src/js/variant-widget/eva-variant-genotype-grid-panel.js
+++ b/src/js/variant-widget/eva-variant-genotype-grid-panel.js
@@ -327,33 +327,35 @@ String.prototype.formatAlleles = function () {
     var first;
     var second;
     var split;
+    var haploid_genotype = (this.indexOf("/") == -1 && this.indexOf("|") == -1);
 
-    if (allels.match(/-1\/-1/)) {
-        allels = './.';
-    }else if(allels.match(/-1\|-1/)){
-        allels = '.|.';
-    }
+    if (!haploid_genotype) {
+        if (allels.match(/-1\/-1/)) {
+            allels = './.';
+        }else if(allels.match(/-1\|-1/)){
+            allels = '.|.';
+        }
 
-    if (this.indexOf("|") > -1) {
-        temp = allels.split("|");
-        split = '|';
-    }else if(this.indexOf("/") > -1) {
-        temp = allels.split("/");
-        split = '/';
-    }
-    if(!_.isEmpty( temp[0]) && !_.isUndefined(temp[0]) && temp[0] > 1){
-        first = '*';
-    }else{
-        first = temp[0];
-    }
+        if (this.indexOf("|") > -1) {
+            temp = allels.split("|");
+            split = '|';
+        }else if(this.indexOf("/") > -1) {
+            temp = allels.split("/");
+            split = '/';
+        }
+        if(!_.isEmpty( temp[0]) && !_.isUndefined(temp[0]) && temp[0] > 1){
+            first = '*';
+        }else{
+            first = temp[0];
+        }
 
-    if(!_.isEmpty( temp[1]) && !_.isUndefined(temp[1]) && temp[1] > 1){
-        second = '*';
-    }else{
-        second = temp[1];
+        if(!_.isEmpty( temp[1]) && !_.isUndefined(temp[1]) && temp[1] > 1){
+            second = '*';
+        }else{
+            second = temp[1];
+        }
+        allels = first+split+second;
     }
-
-    allels = first+split+second;
 
     return allels;
 };

--- a/tests/acceptance/variant_browser.js
+++ b/tests/acceptance/variant_browser.js
@@ -144,6 +144,7 @@ test.describe('Variant Browser ('+config.browser()+')', function() {
         test.it('Genotypes Tab should not be empty and no duplicate Items', function() {
             variantBrowserResetAndWait(driver);
             variantGenotypesTab(driver);
+            variantGenotypesTabWithHaploidGenotypes(driver);
         });
         test.it('Population Statistics should not be empty and no duplicate Items ', function() {
             variantBrowserResetAndWait(driver);
@@ -658,6 +659,22 @@ function variantGenotypesTab(driver){
     waitForVariantsToLoad(driver);
     driver.findElement(By.name("region")).clear();
     driver.findElement(By.name("region")).sendKeys('2:48000000-49000000');
+    clickSubmit(driver);
+    waitForVariantsToLoad(driver);
+    driver.wait(until.elementLocated(By.xpath("//div[@id='variant-browser-grid-body']//table[1]//td[1]/div[text()]")), config.wait()).then(function(text) {
+        safeClick(driver, driver.findElement(By.xpath("//span[text()='Genotypes']")));
+        safeClick(driver, driver.findElement(By.xpath("//div[@id='variant-browser-grid-body']//table[1]")));
+        variantBrowser.genotypesTab(driver);
+    });
+    return driver;
+}
+
+function variantGenotypesTabWithHaploidGenotypes(driver){
+    driver.findElement(By.id("speciesFilter-trigger-picker")).click();
+    driver.findElement(By.xpath("//li[text()='Pig / Sscrofa11.1']")).click();
+    waitForVariantsToLoad(driver);
+    driver.findElement(By.name("region")).clear();
+    driver.findElement(By.name("region")).sendKeys('X:9610000-9611000');
     clickSubmit(driver);
     waitForVariantsToLoad(driver);
     driver.wait(until.elementLocated(By.xpath("//div[@id='variant-browser-grid-body']//table[1]//td[1]/div[text()]")), config.wait()).then(function(text) {

--- a/tests/acceptance/variant_browser_bottom_panel_tests.js
+++ b/tests/acceptance/variant_browser_bottom_panel_tests.js
@@ -133,10 +133,10 @@ module.exports = {
                         });
                         //check study title links
                         rows[i].findElement(By.className("study_link")).getAttribute('href').then(function(text){
-                            assert(text.split("?")[1]).matches(/^eva-study\=PRJ[A-Z0-9]+$/);
+                            assert(text.split("?")[1]).matches(/^eva-study\=[A-Z0-9-_]+$/);
                         },function(err) {});
                         rows[i].findElement(By.className("project_link")).getAttribute('href').then(function(text){
-                            assert(text.split("?")[1]).matches(/^eva-study\=PRJ[A-Z0-9]+$/);
+                            assert(text.split("?")[1]).matches(/^eva-study\=[A-Z0-9-_]+$/);
                         },function(err) {});
                         // check for pie chart study
                         rows[i].findElement(By.xpath("//div[contains(@id,'genotype-count-chart-')]")).getAttribute("innerHTML").then(function(text){


### PR DESCRIPTION
* Update formatAlleles extension function to support haploid genotypes like "0" or "1"
* Add acceptance test for haploid genotypes