### PR TITLE
EVA-1638 — Fix two acceptance tests using Mosquito / AgamP3 genome

### DIFF
--- a/tests/acceptance/variant_browser.js
+++ b/tests/acceptance/variant_browser.js
@@ -302,7 +302,7 @@ function positionFilterBoxValidation(driver){
     variantBrowserResetAndWait(driver);
     driver.findElement(By.id("speciesFilter-trigger-picker")).click();
     driver.findElement(By.xpath("//li[text()='Mosquito / AgamP3']")).click();
-    waitForVariantsToLoad(driver);
+    waitForEmptyVariantsToLoad(driver);
     driver.findElement(By.name("region")).clear();
     driver.findElement(By.name("region")).sendKeys('X:10000000-11000000');
     clickSubmit(driver);
@@ -414,7 +414,7 @@ function variantSearchByGene(driver){
 function checkConsequeceTypeTree(driver){
     driver.findElement(By.id("speciesFilter-trigger-picker")).click();
     driver.findElement(By.xpath("//li[text()='Mosquito / AgamP3']")).click();
-    waitForVariantsToLoad(driver);
+    waitForEmptyVariantsToLoad(driver);
     driver.findElement(By.xpath("//div[@class='variant-browser-option-div form-panel-variant-filter']//div[contains(@id,'treepanel')]//div[@class='x-tool-img x-tool-expand-bottom']")).click();
     driver.findElement(By.xpath("//div[contains(@class,'x-tree-view')]//span[contains(text(),'Transcript Variant')]")).getText().then(function(text){
         assert(text).equalTo("Transcript Variant");
@@ -688,9 +688,8 @@ function variantBrowserResetAndWait(driver) {
     waitForVariantsToLoad(driver);
 }
 
-function waitForVariantsToLoad(driver) {
+function waitForVariantsToLoadGeneral(driver, waitXpath) {
     var maskXpath = "//div[contains(concat(' ', normalize-space(@class),' '), ' x-mask ') and not(contains(@style, 'display: none'))]";
-    var variantsXpath = "//div[@id='variant-browser-grid-body']//table[1]//tr[1]//td[1]//div";
     // First, *optionally* wait for the loading mask to appear
     driver.wait(until.elementLocated(By.xpath(maskXpath)), config.wait()).then(function() {
         driver.wait(function () {
@@ -702,11 +701,19 @@ function waitForVariantsToLoad(driver) {
             config.wait()
         ).then(function () {
             // Finally, wait for the variants to load
-            driver.wait(until.elementLocated(By.xpath(variantsXpath)), config.wait())
+            driver.wait(until.elementLocated(By.xpath(waitXpath)), config.wait())
         })
     }, function(err) {
         console.log('WARN: Mask did not appear (which is alright, the webdriver most likely just missed it)')
     })
+}
+
+function waitForVariantsToLoad(driver) {
+    return waitForVariantsToLoadGeneral(driver, "//div[@id='variant-browser-grid-body']//table[1]//tr[1]//td[1]//div");
+}
+
+function waitForEmptyVariantsToLoad(driver) {
+    return waitForVariantsToLoadGeneral(driver, "//div[@id='variant-browser-grid-body']//div[contains(string(), 'No records to display')]")
 }
 
 function safeClick(driver, element) {


### PR DESCRIPTION
Those two tests are the only ones using Mosquito / AgamP3 genome in the variant browser. Here's the sequence of events for both of them:

```javascript
// Variant browser is reset before the start of the test
variantBrowserResetAndWait(driver);

// Mosquito / AgamP3 genome is chosen
driver.findElement(By.xpath("//li[text()='Mosquito / AgamP3']")).click();
driver.findElement(By.xpath("//li[text()='Mosquito / AgamP3']")).click();

// Waiting for the variants to be loaded before doing anything else
waitForVariantsToLoad(driver);
```

The problem is that `waitForVariantsToLoad(driver)` expects to first see a loading mask to appear (optionally, because it knows it might just miss one) and then for at least one variant to load. However, when you select this mosquito genome in the variant browser, and leave the default coordinates (1:3000000-3100000), there are no variants at this position for this mosquito build. Hence the wait timeouts because it can't find the first variant's `<div>`.

I fixed this by waiting for a “No records to display” message instead, for those two mosquito tests. 