### PR TITLE
EVA-2218 Fix variant view by variant info and fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,10 @@ sudo: false
 language: node_js
 
 node_js:
-    - "7.8.0"
+    - "10.19.0"
+
+addons:
+  chrome: stable
 
 before_script:
   - cd lib/jsorolla

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "bower": "1.8.8",
     "chai": "3.5.0",
     "chai-webdriver": "1.2.0",
-    "chromedriver": "73.0.0",
+    "chromedriver": "86.0.0",
     "geckodriver": "~1.16.2",
     "grunt": "~1.0.4",
     "grunt-bower-task": "~0.4.0",

--- a/src/index.html
+++ b/src/index.html
@@ -1484,7 +1484,7 @@
 
         /* Some times more than one accession ID can be submitted. Ex: rs123, ss234 */
         accessionID = accessionID.replace(/(, | )+/, ',').replace(/\s/g, '')
-        var accessionIDs = accessionID.split(',').map(function trim(x) {return x.trim();});
+        var accessionIDs = accessionID.split(',');
 
         if (!areValidAccessionIDs(accessionIDs)) {
             Ext.Msg.alert('Invalid Accession ID', 'Accession ID must have rs or ss followed by a number (ex: rs123 or ss567)');

--- a/src/index.html
+++ b/src/index.html
@@ -182,7 +182,7 @@
                                 <fieldset>
                                     <div class="inline-block">
                                         <div class="small-10 medium-10 columns">
-                                            <input type="text" name="accessionID" id="accession-search-box" placeholder="ex: rs123 or ss567 or comma-separated RS or SS IDs">
+                                            <input type="text" name="accessionID" id="accession-search-box" placeholder="ex: rs123 or ss567 or comma/space separated RS or SS IDs">
                                         </div>
 
                                         <div class="small-2 medium-2 columns">
@@ -1483,7 +1483,8 @@
         var accessionID = document.getElementById("accession-search-box").value.trim();
 
         /* Some times more than one accession ID can be submitted. Ex: rs123, ss234 */
-        var accessionIDs = accessionID.split(",").map(function trim(x) {return x.trim();});
+        accessionID = accessionID.replace(/(, | )+/, ',').replace(/\s/g, '')
+        var accessionIDs = accessionID.split(',').map(function trim(x) {return x.trim();});
 
         if (!areValidAccessionIDs(accessionIDs)) {
             Ext.Msg.alert('Invalid Accession ID', 'Accession ID must have rs or ss followed by a number (ex: rs123 or ss567)');

--- a/src/js/eva-config.js
+++ b/src/js/eva-config.js
@@ -126,7 +126,7 @@ VARIANT_TYPE_SO_MAP = {"SNV": "SO:0001483",
                        "NO_SEQUENCE_ALTERATION" : "SO:0002073",
                        "MNV": "SO:0002007"};
 SO_SERVICE = "http://www.sequenceontology.org/browser/current_release/term";
-ENA_ASSEMBLY_LOOKUP_SERVICE = "https://www.ebi.ac.uk/ena/data/view";
+ENA_ASSEMBLY_LOOKUP_SERVICE = "https://www.ebi.ac.uk/ena/browser/api/xml";
 NCBI_ASSEMBLY_LOOKUP_SERVICE = "https://www.ncbi.nlm.nih.gov/assembly";
 ASSEMBLY_GCA_TO_GCF_SYNONYMS = {"GCA_000409795.2" : "GCF_000409795.2" /*Vervet Monkey*/,
                                 "GCA_001625215.1" : "GCF_001625215.1" /*Carrot*/,

--- a/src/js/rs-release/rs-release.js
+++ b/src/js/rs-release/rs-release.js
@@ -73,8 +73,8 @@ EvaRsRelease.prototype = {
                     '<p>' + releaseInfo.releaseDescription + '</p>' +
                     '<div>';
 
-        content +=  '<ul class="accordion" data-accordion data-allow-all-closed="true">' +
-                        '<li class="accordion-item" data-accordion-item>' +
+        content +=  '<ul class="accordion" data-accordion data-allow-all-closed="true" data-multi-expand="true">' +
+                        '<li id="accordion-item-new-data" class="accordion-item" data-accordion-item>' +
                             '<a href="#" class="accordion-title">New in RS Release ' + releaseVersion + '</a>' +
                             '<div class="accordion-content" data-tab-content>';
 
@@ -82,7 +82,7 @@ EvaRsRelease.prototype = {
 
         content +=          '</div>' +
             '           </li>' +
-                        '<li class="accordion-item" data-accordion-item>' +
+                        '<li id="accordion-item-data" class="accordion-item" data-accordion-item>' +
                             '<a href="#" class="accordion-title">All RS Release Data</a>' +
                             '<div class="accordion-content" data-tab-content>';
 

--- a/src/js/rs-release/rs-release.js
+++ b/src/js/rs-release/rs-release.js
@@ -75,7 +75,7 @@ EvaRsRelease.prototype = {
 
         content +=  '<ul class="accordion" data-accordion data-allow-all-closed="true" data-multi-expand="true">' +
                         '<li id="accordion-item-new-data" class="accordion-item" data-accordion-item>' +
-                            '<a href="#" class="accordion-title">New in RS Release ' + releaseVersion + '</a>' +
+                            '<a href="#" class="accordion-title">New data in Release ' + releaseVersion + '</a>' +
                             '<div class="accordion-content" data-tab-content>';
 
         content += this.createWhatsNewContent(releaseVersion);
@@ -83,7 +83,7 @@ EvaRsRelease.prototype = {
         content +=          '</div>' +
             '           </li>' +
                         '<li id="accordion-item-data" class="accordion-item" data-accordion-item>' +
-                            '<a href="#" class="accordion-title">All RS Release Data</a>' +
+                            '<a href="#" class="accordion-title">All data</a>' +
                             '<div class="accordion-content" data-tab-content>';
 
         content += this.createReleaseDataTable(releaseVersion);

--- a/src/js/views/eva-multi-variant-view.js
+++ b/src/js/views/eva-multi-variant-view.js
@@ -21,7 +21,7 @@ function EvaMultiVariantView(args) {
     this.id = Utils.genId("EVAMultiVariantView");
     _.extend(this, args);
     this.rendered = false;
-    this.accessionIDs = _.map(decodeURI(this.accessionID).split(","), function trim(x) {return x.trim();});
+    this.accessionIDs = _.map(decodeURI(this.accessionID).split(/(?:, |,| )+/), function trim(x) {return x.trim();});
     this.page = this.page ? this.page: 1;
     //Since the identifier web service does not support multiple identifiers yet,
     //five results at a time seem to provide the best response time

--- a/src/js/views/eva-multi-variant-view.js
+++ b/src/js/views/eva-multi-variant-view.js
@@ -21,7 +21,7 @@ function EvaMultiVariantView(args) {
     this.id = Utils.genId("EVAMultiVariantView");
     _.extend(this, args);
     this.rendered = false;
-    this.accessionIDs = _.map(decodeURI(this.accessionID).split(/(?:, |,| )+/), function trim(x) {return x.trim();});
+    this.accessionIDs = _.map(decodeURI(this.accessionID).split(","), function trim(x) {return x.trim();});
     this.page = this.page ? this.page: 1;
     //Since the identifier web service does not support multiple identifiers yet,
     //five results at a time seem to provide the best response time

--- a/src/js/views/eva-variant-view.js
+++ b/src/js/views/eva-variant-view.js
@@ -673,8 +673,10 @@ EvaVariantView.prototype = {
             return;
         }
 
-        try { this.initGlobalEnv(); } catch (e) { return; }
-        this.storeVariantInfo();
+        this.initGlobalEnv();
+        if (this.species) {
+            this.storeVariantInfo();
+        }
         this.draw();
 
         //sending tracking data to Google Analytics

--- a/src/js/views/eva-variant-view.js
+++ b/src/js/views/eva-variant-view.js
@@ -118,7 +118,7 @@ EvaVariantView.prototype = {
     },
 
     getAssemblyNameForAccession: function(assemblyAccession) {
-        var assemblyENAXmlUrl = ENA_ASSEMBLY_LOOKUP_SERVICE + "/" + assemblyAccession + "&display=xml"
+        var assemblyENAXmlUrl = ENA_ASSEMBLY_LOOKUP_SERVICE + "/" + assemblyAccession + "?display=xml"
         var xmlResult = EvaManager.getAPICallResult(assemblyENAXmlUrl, 'xml', this.assemblyAccessionNotResolvedHandler.bind(this));
 
         if (xmlResult) {

--- a/tests/acceptance/config-manager.js
+++ b/tests/acceptance/config-manager.js
@@ -33,9 +33,7 @@ module.exports = {
             .build();
         driver.manage().window().maximize();
         driver.get(baseURL);
-        // Wait until the species drop down is fully loaded by checking one of the species
-        driver.wait(until.elementLocated(By.xpath("//select[@id='species-drop-down']/option[@value='drerio_grcz10']")),
-                        10000);
+
         chai.use(chaiWebdriver(driver));
         driver.wait(until.elementLocated(By.id("cookie-dismiss")), 10000).then(function(text) {
             driver.findElement(By.xpath("//*[@id='data-protection-agree']")).click();

--- a/tests/acceptance/dbSNP_import.js
+++ b/tests/acceptance/dbSNP_import.js
@@ -25,7 +25,7 @@ test.describe('dbSNP Import Progress ('+config.browser()+')', function() {
     var driver;
     test.before(function() {
         driver = config.initDriver(config.browser());
-        driver.findElement(By.xpath("//li//a[text()='dbSNP Import Progress']")).click();
+        driver.get(config.baseURL()+'?dbSNP-Import-Progress');
     });
 
     test.after(function() {

--- a/tests/acceptance/home_page.js
+++ b/tests/acceptance/home_page.js
@@ -22,7 +22,6 @@ var utils = require('./utils.js');
 config.loadModules();
 
 var INVALID_ACCESSION_ID_ERR_MSG = "Accession ID must have rs or ss followed by a number (ex: rs123 or ss567)";
-var SPECIES_NOT_SELECTED_MSG = "Please select a species";
 
 test.describe('Home Page ('+config.browser()+')', function() {
     var driver;
@@ -88,37 +87,25 @@ function statisticsChartsRendered(driver){
     return driver;
 }
 
-function testAccessionIDClientSideValidation (driver) {
+function testAccessionIDClientSideValidation(driver) {
+    driver.findElement(By.id("accession-search-box")).clear();
+    driver.findElement(By.id("accession-search-box")).sendKeys("r123");
+    driver.findElement(By.id("accession-search-button")).click();
+    utils.assertAlertWindowShown(driver, INVALID_ACCESSION_ID_ERR_MSG);
+
     driver.findElement(By.id("accession-search-box")).clear();
     driver.findElement(By.id("accession-search-box")).sendKeys("rs123#");
     driver.findElement(By.id("accession-search-button")).click();
-    utils.assertAlertWindowShown(driver, SPECIES_NOT_SELECTED_MSG);
+    utils.assertAlertWindowShown(driver, INVALID_ACCESSION_ID_ERR_MSG);
 
-    var dropDownLocator =  By.xpath("//select[@id='species-drop-down']/option[@value='hsapiens_grch37']");
-    driver.wait(until.elementLocated(dropDownLocator), config.wait()).then(function(element) {
-        driver.wait(until.elementIsVisible(element), config.wait()).then(function(element) {
-            // For some reason, send keys works more consistently than click for dropdowns!!
-            driver.findElement(By.xpath("//select[@id='species-drop-down']")).sendKeys("hum");
-        });
-        driver.findElement(By.id("accession-search-box")).clear();
-        driver.findElement(By.id("accession-search-box")).sendKeys("r123");
-        driver.findElement(By.id("accession-search-button")).click();
-        utils.assertAlertWindowShown(driver, INVALID_ACCESSION_ID_ERR_MSG);
+    driver.findElement(By.id("accession-search-box")).clear();
+    driver.findElement(By.id("accession-search-box")).sendKeys("ss123a");
+    driver.findElement(By.id("accession-search-button")).click();
+    utils.assertAlertWindowShown(driver, INVALID_ACCESSION_ID_ERR_MSG);
 
-        driver.findElement(By.id("accession-search-box")).clear();
-        driver.findElement(By.id("accession-search-box")).sendKeys("rs123#");
-        driver.findElement(By.id("accession-search-button")).click();
-        utils.assertAlertWindowShown(driver, INVALID_ACCESSION_ID_ERR_MSG);
-
-        driver.findElement(By.id("accession-search-box")).clear();
-        driver.findElement(By.id("accession-search-box")).sendKeys("ss123a");
-        driver.findElement(By.id("accession-search-button")).click();
-        utils.assertAlertWindowShown(driver, INVALID_ACCESSION_ID_ERR_MSG);
-
-        driver.findElement(By.id("accession-search-box")).clear();
-        driver.findElement(By.id("accession-search-box")).sendKeys("123");
-        driver.findElement(By.id("accession-search-button")).click();
-        utils.assertAlertWindowShown(driver, INVALID_ACCESSION_ID_ERR_MSG);
-    });
+    driver.findElement(By.id("accession-search-box")).clear();
+    driver.findElement(By.id("accession-search-box")).sendKeys("123");
+    driver.findElement(By.id("accession-search-button")).click();
+    utils.assertAlertWindowShown(driver, INVALID_ACCESSION_ID_ERR_MSG);
 }
 

--- a/tests/acceptance/multi_variant_view.js
+++ b/tests/acceptance/multi_variant_view.js
@@ -25,7 +25,7 @@ test.describe('Multiple Variant View - rs IDs', function() {
     var driver;
     test.before(function() {
         driver = config.initDriver(config.browser());
-        driver.get(config.baseURL()+'?variant&accessionID=rs8281491,rs8281492,rs8281493&species=cfamiliaris_31');
+        driver.get(config.baseURL()+'?variant&accessionID=rs8281491,rs8281492,rs8281493');
     });
 
     test.after(function() {
@@ -49,7 +49,7 @@ test.describe('Multiple Variant View - ss IDs - with pagination', function() {
     var driver;
     test.before(function() {
         driver = config.initDriver(config.browser());
-        driver.get(config.baseURL() +'?variant&accessionID=ss33584607,ss34622339,ss34818982,ss32675902,ss1915496708,ss34345272,ss1917607577,ss1917629243,ss1914435361,ss1914691448,ss1914332513&species=cfamiliaris_31&page=2');
+        driver.get(config.baseURL() +'?variant&accessionID=ss33584607,ss34622339,ss34818982,ss32675902,ss1915496708,ss34345272,ss1917607577,ss1917629243,ss1914435361,ss1914691448,ss1914332513&page=2');
     });
 
     test.after(function() {

--- a/tests/acceptance/rs_release.js
+++ b/tests/acceptance/rs_release.js
@@ -1,0 +1,66 @@
+/*
+ * European Variation Archive (EVA) - Open-access database of all types of genetic
+ * variation data from all species
+ *
+ * Copyright 2014 -2020 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var config = require('./config.js');
+config.loadModules();
+
+test.describe('RS Release ('+config.browser()+')', function() {
+    var driver;
+    test.before(function() {
+        driver = config.initDriver(config.browser());
+        driver.findElement(By.xpath("//li//a[text()='RS Release']")).click();
+        expandAccordionsToShowTables();
+    });
+
+    test.after(function() {
+        config.shutdownDriver(driver);
+    });
+
+    test.describe('RS Release table check', function() {
+        test.it('Check "Scientific name" column should not be empty', function() {
+            assertRows("rs-release-scientific-name", /\w+.*$/)
+        });
+
+        test.it('Check "Taxonomy ID" column should not be empty', function() {
+            assertRows("rs-release-tax-id", /^\d+$/)
+        });
+
+        test.it('Check numeric columns should not be empty', function() {
+            assertRows("rs-release-current-rs", /^[,0-9]+$/)
+        });
+    });
+});
+
+function expandAccordionsToShowTables() {
+    driver.findElement(By.id("accordion-item-data")).click();
+    driver.wait(until.elementLocated(By.id("rs-release-table")), config.wait()).then(function() {
+        driver.findElement(By.id("accordion-item-new-data")).click();
+        driver.wait(until.elementLocated(By.id("rs-release-table-new-data")), config.wait());
+    });
+}
+
+function assertRows(className, regex) {
+    driver.findElements(By.className(className)).then(function(rows){
+        for (var i = 0; i < rows.length; i++){
+            rows[i].getText().then(function(text){
+                assert(text).matches(regex);
+            });
+        }
+    });
+}

--- a/tests/acceptance/variant_browser.js
+++ b/tests/acceptance/variant_browser.js
@@ -554,15 +554,15 @@ function variantFilterByMAF(driver){
 
 function checkAnnotationNotification(driver){
     driver.findElement(By.id("speciesFilter-trigger-picker")).click();
-    safeClick(driver, driver.findElement(By.xpath("//li[text()='Mosquito / AaegL3']")));
+    safeClick(driver, driver.findElement(By.xpath("//li[text()='Mosquito / AaegL2']")));
     waitForVariantsToLoad(driver);
     driver.findElement(By.id("annotVersion-trigger-picker")).click();
-    safeClick(driver, driver.findElement(By.xpath("//li[text()='VEP version 89 - Cache version 35']")));
+    safeClick(driver, driver.findElement(By.xpath("//li[text()='VEP version 82 - Cache version 1606']")));
     clickSubmit(driver);
     waitForVariantsToLoad(driver);
     driver.wait(until.elementLocated(By.className("vep_text")), 10000).then(function(text) {
         driver.findElement(By.className("vep_text")).getText().then(function(text){
-            assert(text).matches(/[v][8][9]/);
+            assert(text).matches(/[v][8][2]/);
         });
     });
     return driver;

--- a/tests/acceptance/variant_browser.js
+++ b/tests/acceptance/variant_browser.js
@@ -554,10 +554,10 @@ function variantFilterByMAF(driver){
 
 function checkAnnotationNotification(driver){
     driver.findElement(By.id("speciesFilter-trigger-picker")).click();
-    safeClick(driver, driver.findElement(By.xpath("//li[text()='Mosquito / AaegL2']")));
+    safeClick(driver, driver.findElement(By.xpath("//li[text()='Mouse / GRCm38.p3']")));
     waitForVariantsToLoad(driver);
     driver.findElement(By.id("annotVersion-trigger-picker")).click();
-    safeClick(driver, driver.findElement(By.xpath("//li[text()='VEP version 82 - Cache version 1606']")));
+    safeClick(driver, driver.findElement(By.xpath("//li[text()='VEP version 82 - Cache version 82']")));
     clickSubmit(driver);
     waitForVariantsToLoad(driver);
     driver.wait(until.elementLocated(By.className("vep_text")), 10000).then(function(text) {

--- a/tests/acceptance/variant_view.js
+++ b/tests/acceptance/variant_view.js
@@ -26,7 +26,7 @@ test.describe('Variant View - rs exclusive to Accessioning', function() {
     var driver;
     test.before(function() {
         driver = config.initDriver(config.browser());
-        driver.get(config.baseURL()+'?variant&accessionID=RS884750506&species=dcarota_ASM162521v1');
+        driver.get(config.baseURL()+'?variant&accessionID=RS884750506');
     });
 
     test.after(function() {
@@ -51,7 +51,7 @@ test.describe('Variant View - ss exclusive to Accessioning', function() {
     var driver;
     test.before(function() {
         driver = config.initDriver(config.browser());
-        driver.get(config.baseURL()+'?variant&accessionID=ss1996903385&species=dcarota_ASM162521v1');
+        driver.get(config.baseURL()+'?variant&accessionID=ss1996903385');
     });
 
     test.after(function() {
@@ -71,7 +71,7 @@ test.describe('Variant View - rs found in both EVA and Accessioning', function()
     var driver;
     test.before(function() {
         driver = config.initDriver(config.browser());
-        driver.get(config.baseURL()+'?variant&accessionID=rs869710784&species=csabaeus_chlsab11');
+        driver.get(config.baseURL()+'?variant&accessionID=rs869710784');
     });
 
     test.after(function() {
@@ -84,7 +84,9 @@ test.describe('Variant View - rs found in both EVA and Accessioning', function()
     variantView.runTableTest("Variant Information Section", "Variant Information Section has the correct values for attributes",
                 "table", "variant-view-summary", expectedResults, variantView.checkSection);
 
-    expectedResults = [{"ID": "ss1991442915", "Submitter Handle": "PRJEB7923", "Chromosome/Contig accession": "CM001952.2", "Chromosome": "11",
+    expectedResults = [{"ID": "ss5227751341", "Submitter Handle": "PRJEB22988", "Chromosome/Contig accession": "CM001952.2", "Chromosome": "11",
+                        "Start": "50921862", "End": "50921862", "Reference": "C", "Alternate": "G", "Created Date": "6 July 2019"},
+                        {"ID": "ss1991442915", "Submitter Handle": "PRJEB7923", "Chromosome/Contig accession": "CM001952.2", "Chromosome": "11",
                         "Start": "50921862", "End": "50921862", "Reference": "C", "Alternate": "G", "Created Date": "5 May 2016"}
                       ];
     variantView.runTableTest("Submitted Variant Section", "Submitted Variant Section has the correct values for attributes",
@@ -95,7 +97,7 @@ test.describe('Variant View - ss found in both EVA and Accessioning', function()
     var driver;
     test.before(function() {
         driver = config.initDriver(config.browser());
-        driver.get(config.baseURL()+'?variant&accessionID=ss1991442915&species=csabaeus_chlsab11');
+        driver.get(config.baseURL()+'?variant&accessionID=ss1991442915');
     });
 
     test.after(function() {
@@ -147,7 +149,7 @@ test.describe('Variant View - ss by position', function() {
         config.shutdownDriver(driver);
     });
 
-    var expectedResults = [{"Organism": "Human", "Assembly": "GCA_000001405.1 (GRCh37)", "Submitter Handle": "", "Chromosome/Contig accession": "",
+    var expectedResults = [{"Organism": "Human", "Assembly": "GCA_000001405.14 (GRCh37)", "Submitter Handle": "", "Chromosome/Contig accession": "",
                             "Chromosome":"1", "Start": "3000017", "End": "3000017", "Reference": "C", "Alternate": "T", "ID":"ss1289423512",
                             "Type": "SNV", "Allele frequencies / genotypes available?": "Yes",
                             "Alleles match reference assembly?": "", "Passed allele checks?": "",
@@ -198,50 +200,25 @@ test.describe('Variant View - ss by position', function() {
                     "div", "popstats_C_T", expectedResults, variantView.checkPopulationStatsGrid);
 });
 
-test.describe('Variant View - Invalid SS', function() {
+test.describe('Variant View - Invalid RS', function() {
     var driver;
     test.before(function() {
         driver = config.initDriver(config.browser());
-        driver.get(config.baseURL()+'?variant&accessionID=rs123&species=dcarota_ASM162521v1');
+        driver.get(config.baseURL()+'?variant&accessionID=rs1234');
     });
 
     test.after(function() {
         config.shutdownDriver(driver);
     });
 
-    variantView.checkNoDataAvailable("Invalid SS", "Invalid SS shows proper error message", "div", "summary-grid", "No Data Available in EVA for rs123.");
-});
-
-test.describe('Variant View - Human RS exclusive to EVA', function() {
-    var driver;
-    test.before(function() {
-        driver = config.initDriver(config.browser());
-        driver.get(config.baseURL()+'?variant&accessionID=rs781916484&species=hsapiens_grch37');
-    });
-
-    test.after(function() {
-        config.shutdownDriver(driver);
-    });
-
-    var expectedResults = [{"Organism": "Human", "Assembly": "GCA_000001405.1 (GRCh37)", "Chromosome/Contig accession": "",
-                            "Chromosome": "10", "Start": "49731571", "ID": "rs781916484", "Type": "INS",
-                            "Created Date": ""}];
-    variantView.runTableTest("Variant Information Section", "Variant Information Section has the correct values for attributes",
-                "table", "variant-view-summary", expectedResults, variantView.checkSection);
-
-    expectedResults = [{"ID": "ss1536651894", "Study": "", "Chromosome/Contig accession": "", "Chromosome": "10",
-                        "Start": "49731571", "End": "49731571", "Reference": "",
-                        "Alternate": "G", "Type": "INS", "Created Date": ""}
-                      ];
-    variantView.runTableTest("Submitted Variant Section", "Submitted Variant Section has the correct values for attributes",
-                "table", "submitted-variant-summary", expectedResults, variantView.checkSection);
+    variantView.checkNoDataAvailable("Invalid RS", "Invalid RS shows proper error message", "div", "summary-grid", "No Data Available in EVA for rs1234.");
 });
 
 test.describe('Variant View - Human RS exclusive to accessioning', function() {
     var driver;
     test.before(function() {
         driver = config.initDriver(config.browser());
-        driver.get(config.baseURL()+'?variant&accessionID=rs2913&species=hsapiens_grch38&assemblyAccession=GCA_000001405.27');
+        driver.get(config.baseURL()+'?variant&accessionID=rs2913');
     });
 
     test.after(function() {

--- a/tests/acceptance/variant_view.js
+++ b/tests/acceptance/variant_view.js
@@ -149,7 +149,7 @@ test.describe('Variant View - ss by position', function() {
         config.shutdownDriver(driver);
     });
 
-    var expectedResults = [{"Organism": "Human", "Assembly": "GCA_000001405.14 (GRCh37)", "Submitter Handle": "", "Chromosome/Contig accession": "",
+    var expectedResults = [{"Organism": "Human", "Assembly": "GCA_000001405.14 (GRCh37.p13)", "Submitter Handle": "", "Chromosome/Contig accession": "",
                             "Chromosome":"1", "Start": "3000017", "End": "3000017", "Reference": "C", "Alternate": "T", "ID":"ss1289423512",
                             "Type": "SNV", "Allele frequencies / genotypes available?": "Yes",
                             "Alleles match reference assembly?": "", "Passed allele checks?": "",


### PR DESCRIPTION
This PR is still work in progress, **do not merge**. Is not marked as draft because I need travis to run

- [x]  Fix variant view when querying by variant variant info (chromosome:position:ref:alt). See [here](https://wwwdev.ebi.ac.uk/eva/EVA-2218/?variant=X:9610124::TTT&species=sscrofa_111&annotationVersion=89_91)
- [x] Fix tests affected when removing the species dropdown from the SNP search
- [x] Check tests failing because of CORS in ENA web services (not getting assembly name)
- [x] Allow to separate by spaces in the SNP search
- [x] Fix travis tests that were failing due to the chromedriver version
- [x] Update tests from dbSNP import progress report to navigate to the page instead of clicking in the tab
- [x] Add tests for RS Release page